### PR TITLE
New: `WriteBus.contracomposeWriter`

### DIFF
--- a/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
@@ -17,11 +17,15 @@ class WriteBus[A] extends Observer[A] {
     new EventBusSource(stream, sourceStream, owner)
   }
 
+  def contracomposeWriter[B](operator: EventStream[B] => EventStream[A])(implicit owner: Owner): WriteBus[B] = {
+    val mapBus = new WriteBus[B]
+    addSource(mapBus.stream.compose(operator))(owner)
+    mapBus
+  }
+
   /** Behaves similar to `contramap`, but gives you a WriteBus, not just an Observer */
   def contramapWriter[B](project: B => A)(implicit owner: Owner): WriteBus[B] = {
-    val mapBus = new WriteBus[B]
-    addSource(mapBus.stream.map(project))(owner)
-    mapBus
+    contracomposeWriter[B](_.map(project))(owner)
   }
 
   /** Behaves similar to `filter`, but gives you a WriteBus, not just an Observer */


### PR DESCRIPTION
Allows people to provide an operator to transform the write-bus stream.

`contraCompose` is more general than `contramapWriter`, as the first takes
an operator on streams and the second a mapping function on its events.

The advantage of having `contraCompose` is that it provides a way for
people to combine streams.

Now `contramapWriter` is defined in terms of `contraCompose`.