### PR TITLE
API: Allow users to override Owner method to create truly noop owners

### DIFF
--- a/src/main/scala/com/raquo/airstream/ownership/Owner.scala
+++ b/src/main/scala/com/raquo/airstream/ownership/Owner.scala
@@ -36,8 +36,10 @@ trait Owner {
     }
   }
 
-  private[ownership] def own(owned: Owned): Unit = {
+  protected[this] def _own(owned: Owned): Unit = {
     possessions.push(owned)
     onOwned(owned)
   }
+
+  @inline private[ownership] def own(owned: Owned): Unit = _own(owned)
 }


### PR DESCRIPTION
@cornerman Following up on our [gitter discussion](https://gitter.im/Laminar_/Airstream?at=5d85000cb9f8210ed5be0bc1) here's my proposed way to let you override the `own` method to make a custom `Owner` that is truly no-op.

In my current design, I need to keep the `own` method locked down to prevent end users from calling it, but I also need to allow the trait `Owned` (which is also in package `ownership`) to call it.

I don't think such an access modifier is possible with just one method, so instead I moved the implementation that you can override into one method, and made that method available to trait `Owned` via another method. I'm not super sure if this is good practice or a code smell. Please let me know if you have concerns.