### PR TITLE
Airstream v0.11.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-# Changelog
+# Changelog (pre-v0.11.0)
 
 Breaking changes in **bold**.
 
+---
+
+#### For versions v0.11.0 and up, see [laminar.dev/blog](https://laminar.dev/blog)
+
+---
 
 #### v0.10.2 – Sep 2020
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ enablePlugins(ScalaJSPlugin)
 enablePlugins(ScalaJSBundlerPlugin)
 
 libraryDependencies ++= Seq(
-  "org.scala-js" %%% "scalajs-dom" % "1.0.0", // This has no runtime cost. We only use it for `Debug.log` // @TODO[Elegance] Reconsider
-  "org.scalatest" %%% "scalatest" % "3.1.1" % Test
+  "org.scala-js" %%% "scalajs-dom" % "1.1.0", // This has no runtime cost. We only use it for `Debug.log` // @TODO[Elegance] Reconsider
+  "org.scalatest" %%% "scalatest" % "3.2.0" % Test
 )
 
 scalacOptions ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
 

--- a/release.sbt
+++ b/release.sbt
@@ -4,9 +4,9 @@ normalizedName := "airstream"
 
 organization := "com.raquo"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.3"
 
-crossScalaVersions := Seq("2.12.11", "2.13.1")
+crossScalaVersions := Seq("2.12.11", "2.13.3")
 
 homepage := Some(url("https://github.com/raquo/Airstream"))
 

--- a/src/main/scala/com/raquo/airstream/core/Observable.scala
+++ b/src/main/scala/com/raquo/airstream/core/Observable.scala
@@ -70,6 +70,20 @@ trait Observable[+A] {
     strategy.flatten(map(compose))
   }
 
+  def toSignal[AA >: A](initialIfStream: => AA): Signal[AA] = {
+    this match {
+      case s: Signal[A @unchecked] => s
+      case s: EventStream[A @unchecked] => s.startWith(initialIfStream)
+    }
+  }
+
+  def toStreamOrSignalChanges: EventStream[A] = {
+    this match {
+      case s: EventStream[A @unchecked] => s
+      case s: Signal[A @unchecked] => s.changes
+    }
+  }
+
   // @TODO[API] print with dom.console.log automatically only if a JS value detected? Not sure if possible to do well.
 
   /** print events using println - use for Scala values */

--- a/src/main/scala/com/raquo/airstream/eventbus/EventBus.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/EventBus.scala
@@ -2,7 +2,6 @@ package com.raquo.airstream.eventbus
 
 import com.raquo.airstream.eventbus.WriteBus.{BusTryTuple, BusTuple}
 import com.raquo.airstream.eventstream.EventStream
-import com.raquo.airstream.util.hasDuplicateTupleKeys
 
 import scala.util.Try
 
@@ -33,9 +32,6 @@ object EventBus {
   def emit(
     values: EventBusTuple[_]*
   ): Unit = {
-    if (hasDuplicateTupleKeys(values)) {
-      throw new Exception("Unable to EventBus.emit: the provided list of event buses has duplicates")
-    }
     WriteBus.emit(values.map(value => (value._1.writer, value._2).asInstanceOf[BusTuple[_]]): _*)
   }
 
@@ -45,9 +41,6 @@ object EventBus {
   def emitTry[A](
     values: EventBusTryTuple[A]*
   ): Unit = {
-    if (hasDuplicateTupleKeys(values)) {
-      throw new Exception("Unable to EventBus.emitTry: the provided list of event buses has duplicates")
-    }
     WriteBus.emitTry(values.map(value => (value._1.writer, value._2).asInstanceOf[BusTryTuple[_]]): _*)
   }
 }

--- a/src/main/scala/com/raquo/airstream/eventbus/EventBus.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/EventBus.scala
@@ -2,6 +2,7 @@ package com.raquo.airstream.eventbus
 
 import com.raquo.airstream.eventbus.WriteBus.{BusTryTuple, BusTuple}
 import com.raquo.airstream.eventstream.EventStream
+import com.raquo.airstream.util.hasDuplicateTupleKeys
 
 import scala.util.Try
 
@@ -32,6 +33,9 @@ object EventBus {
   def emit(
     values: EventBusTuple[_]*
   ): Unit = {
+    if (hasDuplicateTupleKeys(values)) {
+      throw new Exception("Unable to EventBus.emit: the provided list of event buses has duplicates")
+    }
     WriteBus.emit(values.map(value => (value._1.writer, value._2).asInstanceOf[BusTuple[_]]): _*)
   }
 
@@ -41,6 +45,9 @@ object EventBus {
   def emitTry[A](
     values: EventBusTryTuple[A]*
   ): Unit = {
+    if (hasDuplicateTupleKeys(values)) {
+      throw new Exception("Unable to EventBus.emitTry: the provided list of event buses has duplicates")
+    }
     WriteBus.emitTry(values.map(value => (value._1.writer, value._2).asInstanceOf[BusTryTuple[_]]): _*)
   }
 }

--- a/src/main/scala/com/raquo/airstream/eventbus/EventBusStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/EventBusStream.scala
@@ -42,7 +42,8 @@ class EventBusStream[A] private[eventbus] (writeBus: WriteBus[A]) extends EventS
     // fired as an internal observer. WriteBus calls this method manually, so it checks .isStarted on its own.
     // @TODO ^^^^ We should document this contract in InternalObserver
 
-    // println("NEW TRX from EventBusStream: " + nextValue.toString)
+    //println(s"> init trx from EventBusStream(${nextValue})")
+
     new Transaction(fireValue(nextValue, _))
   }
 

--- a/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
@@ -92,6 +92,7 @@ object WriteBus {
     * Example usage: emitTry(writeBus1 -> value1, writeBus2 -> value2)
     */
   def emit(values: BusTuple[_]*): Unit = {
+    //println(s"> init trx from WriteBus.emit($values)")
     new Transaction(trx => values.foreach(emitValue(_, trx)))
   }
 
@@ -99,6 +100,7 @@ object WriteBus {
     * Example usage: emitTry(writeBus1 -> Success(value1), writeBus2 -> Failure(error2))
     */
   def emitTry(values: BusTryTuple[_]*): Unit = {
+    //println(s"> init trx from WriteBus.emitTry($values)")
     new Transaction(trx => values.foreach(emitTryValue(_, trx)))
   }
 

--- a/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
@@ -3,6 +3,7 @@ package com.raquo.airstream.eventbus
 import com.raquo.airstream.core.{Observer, Transaction}
 import com.raquo.airstream.eventstream.EventStream
 import com.raquo.airstream.ownership.{Owner, Subscription}
+import com.raquo.airstream.util.hasDuplicateTupleKeys
 
 import scala.util.Try
 
@@ -93,6 +94,9 @@ object WriteBus {
     */
   def emit(values: BusTuple[_]*): Unit = {
     //println(s"> init trx from WriteBus.emit($values)")
+    if (hasDuplicateTupleKeys(values)) {
+      throw new Exception("Unable to {EventBus,WriteBus}.emit: the provided list of event buses has duplicates. You can't make an observable emit more than one event per transaction.")
+    }
     new Transaction(trx => values.foreach(emitValue(_, trx)))
   }
 
@@ -101,6 +105,9 @@ object WriteBus {
     */
   def emitTry(values: BusTryTuple[_]*): Unit = {
     //println(s"> init trx from WriteBus.emitTry($values)")
+    if (hasDuplicateTupleKeys(values)) {
+      throw new Exception("Unable to {EventBus,WriteBus}.emitTry: the provided list of event buses has duplicates. You can't make an observable emit more than one event per transaction.")
+    }
     new Transaction(trx => values.foreach(emitTryValue(_, trx)))
   }
 

--- a/src/main/scala/com/raquo/airstream/eventstream/ConcurrentFutureStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventstream/ConcurrentFutureStream.scala
@@ -37,6 +37,7 @@ class ConcurrentFutureStream[A](
         if (!dropPreviousValues || (nextFutureIndex > lastEmittedValueIndex)) {
           lastEmittedValueIndex = nextFutureIndex
           // @TODO[API] Should lastEmittedValueIndex be updated only on success or also on failure?
+          //println(s"> init trx from ConcurrentFutureStream.onNext")
           new Transaction(fireTry(nextValue, _))
         }
       }

--- a/src/main/scala/com/raquo/airstream/eventstream/DebounceEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventstream/DebounceEventStream.scala
@@ -33,6 +33,7 @@ class DebounceEventStream[A](
     maybeLastTimeoutHandle.foreach(js.timers.clearTimeout)
     maybeLastTimeoutHandle = js.defined(
       js.timers.setTimeout(delayFromLastEventMillis) {
+        //println(s"> init trx from DebounceEventStream.onTry($nextValue)")
         new Transaction(fireTry(nextValue, _))
       }
     )

--- a/src/main/scala/com/raquo/airstream/eventstream/DelayEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventstream/DelayEventStream.scala
@@ -15,6 +15,7 @@ class DelayEventStream[A](
 
   override protected[airstream] def onNext(nextValue: A, transaction: Transaction): Unit = {
     js.timers.setTimeout(delayMillis) {
+      //println(s"> init trx from DelayEventStream.onNext($nextValue)")
       new Transaction(fireValue(nextValue, _))
     }
   }

--- a/src/main/scala/com/raquo/airstream/eventstream/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventstream/EventStream.scala
@@ -73,7 +73,7 @@ trait EventStream[+A] extends Observable[A] {
 
   @inline def startWithNone: Signal[Option[A]] = toWeakSignal
 
-  def toSignal[B >: A](initial: => B): Signal[B] = {
+  override def toSignal[B >: A](initial: => B): Signal[B] = {
     toSignalWithTry(Success(initial))
   }
 

--- a/src/main/scala/com/raquo/airstream/eventstream/FutureEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventstream/FutureEventStream.scala
@@ -23,7 +23,10 @@ class FutureEventStream[A](future: Future[A], emitIfFutureCompleted: Boolean) ex
     // @TODO[API] Do we need "isStarted" filter on these? Doesn't seem to affect anything for now...
     future.onComplete(_.fold(
       nextError => new Transaction(fireError(nextError, _)),
-      nextValue => new Transaction(fireValue(nextValue, _))
+      nextValue => {
+        //println(s"> init trx from FutureEventStream.init($nextValue)")
+        new Transaction(fireValue(nextValue, _))
+      }
     ))
   }
 }

--- a/src/main/scala/com/raquo/airstream/eventstream/SeqEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventstream/SeqEventStream.scala
@@ -19,7 +19,10 @@ class SeqEventStream[A](events: Seq[Try[A]], emitOnce: Boolean) extends EventStr
   override protected[this] def onStart(): Unit = {
     super.onStart()
     if (!emitOnce || !hasEmitted) {
-      events.foreach(event => new Transaction(fireTry(event, _)))
+      events.foreach { event =>
+        //println(s"> init trx from SeqEventStream(${event})")
+        new Transaction(fireTry(event, _))
+      }
     }
     if (!hasEmitted) {
       hasEmitted = true

--- a/src/main/scala/com/raquo/airstream/eventstream/SwitchEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventstream/SwitchEventStream.scala
@@ -38,7 +38,10 @@ class SwitchEventStream[I, O](
 
   // @TODO[Elegance] Maybe we should abstract away this kind of internal observer
   private[this] val internalEventObserver: InternalObserver[O] = InternalObserver[O](
-    onNext = (nextEvent, _) => new Transaction(fireValue(nextEvent, _)),
+    onNext = (nextEvent, _) => {
+      //println(s"> init trx from SwitchEventStream.onValue(${nextEvent})")
+      new Transaction(fireValue(nextEvent, _))
+    },
     onError = (nextError, _) => new Transaction(fireError(nextError, _))
   )
 

--- a/src/main/scala/com/raquo/airstream/ownership/ManualOwner.scala
+++ b/src/main/scala/com/raquo/airstream/ownership/ManualOwner.scala
@@ -1,0 +1,14 @@
+package com.raquo.airstream.ownership
+
+/** All this class does is expose the method to kill subscriptions.
+  * Just a small convenience for ad-hoc integrations
+  *
+  * Please note that this is NOT a [[OneTimeOwner]].
+  * If that's what you need, copy this code but extend [[OneTimeOwner]] instead of [[Owner]].
+  */
+class ManualOwner extends Owner {
+
+  override def killSubscriptions(): Unit = {
+    super.killSubscriptions()
+  }
+}

--- a/src/main/scala/com/raquo/airstream/ownership/OneTimeOwner.scala
+++ b/src/main/scala/com/raquo/airstream/ownership/OneTimeOwner.scala
@@ -1,0 +1,28 @@
+package com.raquo.airstream.ownership
+
+/** Owner that can not be used after it was killed. Used in Laminar via [[DynamicOwner]].
+  *
+  * @param onAccessAfterKilled
+  *          Called if you attempt to use this owner after it was killed.
+  *          It's intended to log and/or throw for reporting / debugging purposes.
+  */
+class OneTimeOwner(onAccessAfterKilled: () => Unit) extends Owner {
+
+  private var _isKilledForever: Boolean = false
+
+  @inline def isKilledForever: Boolean = _isKilledForever
+
+  override private[ownership] def own(subscription: Subscription): Unit = {
+    if (_isKilledForever) {
+      subscription.onKilledByOwner()
+      onAccessAfterKilled()
+    } else {
+      super.own(subscription)
+    }
+  }
+
+  override protected[this] def killSubscriptions(): Unit = {
+    super.killSubscriptions()
+    _isKilledForever = true
+  }
+}

--- a/src/main/scala/com/raquo/airstream/ownership/Owner.scala
+++ b/src/main/scala/com/raquo/airstream/ownership/Owner.scala
@@ -34,7 +34,7 @@ trait Owner {
     */
   protected[this] def onOwned(subscription: Subscription): Unit = ()
 
-  def onKilledExternally(subscription: Subscription): Unit = {
+  private[ownership] def onKilledExternally(subscription: Subscription): Unit = {
     val index = subscriptions.indexOf(subscription)
     if (index != -1) {
       subscriptions.splice(index, deleteCount = 1)

--- a/src/main/scala/com/raquo/airstream/ownership/Subscription.scala
+++ b/src/main/scala/com/raquo/airstream/ownership/Subscription.scala
@@ -1,7 +1,6 @@
 package com.raquo.airstream.ownership
 
-import com.raquo.airstream.core.{Observable, Observer, Transaction}
-
+// @TODO[API] Change cleanup from () => Unit to : => Unit? WOuld it be possible to override such a field?
 /** Represents a leaky resource that needs to be cleaned up.
   *
   * Subscription is linked for its life to a given owner.

--- a/src/main/scala/com/raquo/airstream/signal/FutureSignal.scala
+++ b/src/main/scala/com/raquo/airstream/signal/FutureSignal.scala
@@ -30,6 +30,9 @@ class FutureSignal[A](
   )
 
   if (!future.isCompleted) {
-    future.onComplete(value => new Transaction(fireTry(value.map(Some(_)), _)))
+    future.onComplete(value => {
+      //println(s"> init trx from FutureSignal($value)")
+      new Transaction(fireTry(value.map(Some(_)), _))
+    })
   }
 }

--- a/src/main/scala/com/raquo/airstream/signal/Signal.scala
+++ b/src/main/scala/com/raquo/airstream/signal/Signal.scala
@@ -65,8 +65,8 @@ trait Signal[+A] extends Observable[A] {
     * @param makeInitial Note: guarded against exceptions
     * @param fn Note: guarded against exceptions
     */
-  def fold[B](makeInitial: A => B)(fn: (B, A) => B): Signal[B] = {
-    foldRecover(
+  def foldLeft[B](makeInitial: A => B)(fn: (B, A) => B): Signal[B] = {
+    foldLeftRecover(
       parentInitial => parentInitial.map(makeInitial)
     )(
       (currentValue, nextParentValue) => Try(fn(currentValue.get, nextParentValue.get))
@@ -79,7 +79,7 @@ trait Signal[+A] extends Observable[A] {
     * @param fn (currentValue, nextParentValue) => nextValue
     * @return
     */
-  def foldRecover[B](makeInitial: Try[A] => Try[B])(fn: (Try[B], Try[A]) => Try[B]): Signal[B] = {
+  def foldLeftRecover[B](makeInitial: Try[A] => Try[B])(fn: (Try[B], Try[A]) => Try[B]): Signal[B] = {
     new FoldLeftSignal(
       parent = this,
       makeInitialValue = () => makeInitial(tryNow()),

--- a/src/main/scala/com/raquo/airstream/signal/SwitchSignal.scala
+++ b/src/main/scala/com/raquo/airstream/signal/SwitchSignal.scala
@@ -25,7 +25,10 @@ class SwitchSignal[A](
   private[this] var currentSignalTry: Try[Signal[A]] = parent.tryNow()
 
   private[this] val internalEventObserver: InternalObserver[A] = InternalObserver.fromTry[A](
-    onTry = (nextTry, _) => new Transaction(fireTry(nextTry, _))
+    onTry = (nextTry, _) => {
+      //println(s"> init trx from SwitchSignal.onValue($nextTry)")
+      new Transaction(fireTry(nextTry, _))
+    }
   )
 
   override protected[airstream] def onTry(nextSignalTry: Try[Signal[A]], transaction: Transaction): Unit = {
@@ -36,6 +39,7 @@ class SwitchSignal[A](
     nextSignalTry.foreach { nextSignal =>
       nextSignal.addInternalObserver(internalEventObserver)
     }
+    //println(s"> init trx from SwitchSignal.onTry")
     // Update this signal's value with nextSignal's current value (or an error if we don't have nextSignal)
     new Transaction(fireTry(nextSignalTry.flatMap(_.tryNow()), _))
   }

--- a/src/main/scala/com/raquo/airstream/signal/Var.scala
+++ b/src/main/scala/com/raquo/airstream/signal/Var.scala
@@ -96,7 +96,7 @@ object Var {
   def setTry(values: VarTryTuple[_]*): Unit = {
     //println(s"> init trx from Var.set/setTry")
     if (hasDuplicateTupleKeys(values)) {
-      throw new Exception("Unable to Var.set/setTry: the provided list of vars has duplicates")
+      throw new Exception("Unable to Var.{set,setTry}: the provided list of vars has duplicates. You can't make an observable emit more than one event per transaction.")
     }
     new Transaction(trx => values.foreach(setTryValue(_, trx)))
   }
@@ -114,7 +114,7 @@ object Var {
     */
   def update(mods: VarModTuple[_]*): Unit = {
     if (hasDuplicateTupleKeys(mods)) {
-      throw new Exception("Unable to Var.update: the provided list of vars has duplicates")
+      throw new Exception("Unable to Var.update: the provided list of vars has duplicates. You can't make an observable emit more than one event per transaction.")
     }
     val tryMods: Seq[VarTryModTuple[_]] = mods.map(modToTryModTuple(_))
     //println(s"> init trx from Var.update")
@@ -136,7 +136,7 @@ object Var {
   def tryUpdate(mods: VarTryModTuple[_]*): Unit = {
     //println(s"> init trx from Var.tryUpdate")
     if (hasDuplicateTupleKeys(mods)) {
-      throw new Exception("Unable to Var.tryUpdate: the provided list of vars has duplicates")
+      throw new Exception("Unable to Var.tryUpdate: the provided list of vars has duplicates. You can't make an observable emit more than one event per transaction.")
     }
     new Transaction(trx => {
       val tryValues: Seq[VarTryTuple[_]] = mods.map(tryModToTryTuple(_))

--- a/src/main/scala/com/raquo/airstream/signal/Var.scala
+++ b/src/main/scala/com/raquo/airstream/signal/Var.scala
@@ -104,6 +104,10 @@ object Var {
   /** Modify multiple Vars in the same Transaction
     * Example usage: Var.update(var1 -> value1 => value1 + 1, var2 -> value2 => value2 * 2)
     *
+    * Mod functions should be PURE and MUST NOT THROW.
+    * If you try to update a failed Var, or if some of the mods throw,
+    * `Var.update` will throw and none of the Vars will update.
+    *
     * @throws Exception if currentValue of any of the vars is a Failure.
     *                   This is atomic: an exception in any of the vars will prevent any of
     *                   the batched updates in this call from going through.

--- a/src/main/scala/com/raquo/airstream/util/package.scala
+++ b/src/main/scala/com/raquo/airstream/util/package.scala
@@ -3,4 +3,8 @@ package com.raquo.airstream
 package object util {
 
   type Id[A] = A
+
+  def hasDuplicateTupleKeys[K](tuples: Seq[(K, _)]): Boolean = {
+    tuples.size != tuples.map(_._1).toSet.size
+  }
 }

--- a/src/main/scala/com/raquo/airstream/util/package.scala
+++ b/src/main/scala/com/raquo/airstream/util/package.scala
@@ -4,7 +4,7 @@ package object util {
 
   type Id[A] = A
 
-  def hasDuplicateTupleKeys[K](tuples: Seq[(K, _)]): Boolean = {
+  def hasDuplicateTupleKeys[K[_]](tuples: Seq[(K[_], _)]): Boolean = {
     tuples.size != tuples.map(_._1).toSet.size
   }
 }

--- a/src/test/scala/com/raquo/airstream/core/GlitchSpec.scala
+++ b/src/test/scala/com/raquo/airstream/core/GlitchSpec.scala
@@ -81,7 +81,7 @@ class GlitchSpec extends UnitSpec {
     val bus = new EventBus[Int]
 
     val tens = bus.events.map(_ * 10)
-    val hundreds = tens.map(_ * 10).toSignal(0)
+    val hundreds = tens.map(_ * 10).toSignal(initial = 0)
 
     val tuples = tens.withCurrentValueOf(hundreds)
       .map(Calculation.log("tuples", calculations))

--- a/src/test/scala/com/raquo/airstream/core/GlitchSpec.scala
+++ b/src/test/scala/com/raquo/airstream/core/GlitchSpec.scala
@@ -449,39 +449,4 @@ class GlitchSpec extends UnitSpec {
 
     stateVar.now() shouldBe State(List(0, 1))
   }
-
-  it("Nested transactions order and correctness") {
-
-    val owner = new TestableOwner
-
-    var n = 0
-    val clickBus = new EventBus[Unit]
-    val log = Var[List[Int]](Nil)
-    clickBus
-      .events
-      .foreach { _ =>
-        n = n + 2
-        log.update(curr => {
-          log.update(curr => curr :+ -1)
-          log.update(curr => {
-            log.update(curr => curr :+ -3)
-            log.update(curr => curr :+ -4)
-            curr :+ -2
-          })
-          log.update(curr => curr :+ -5)
-          curr :+ (n - 2)
-        })
-        log.update(curr => curr :+ (n - 1))
-      }(owner)
-
-    clickBus.writer.onNext(())
-
-    log.now() shouldBe List(0, -1, -2, -3, -4, -5, 1)
-
-    // --
-
-    clickBus.writer.onNext(())
-
-    log.now() shouldBe List(0, -1, -2, -3, -4, -5, 1, 2, -1, -2, -3, -4, -5, 3)
-  }
 }

--- a/src/test/scala/com/raquo/airstream/core/TransactionSpec.scala
+++ b/src/test/scala/com/raquo/airstream/core/TransactionSpec.scala
@@ -1,0 +1,142 @@
+package com.raquo.airstream.core
+
+import com.raquo.airstream.UnitSpec
+import com.raquo.airstream.eventbus.EventBus
+import com.raquo.airstream.fixtures.{Effect, TestableOwner}
+import com.raquo.airstream.signal.Var
+
+import scala.collection.mutable
+import scala.util.Try
+
+/** A collection of tests that ensure that there are no FRP glitches */
+class TransactionSpec extends UnitSpec {
+
+  it("Nested transactions order and correctness") {
+
+    val owner = new TestableOwner
+
+    var n = 0
+    val clickBus = new EventBus[Unit]
+    val log = Var[List[Int]](Nil)
+
+    clickBus
+      .events
+      .foreach { _ =>
+        n = n + 2
+        log.update(curr => {
+          log.update(curr => curr :+ -1)
+          log.update(curr => {
+            log.update(curr => curr :+ -3)
+            log.update(curr => curr :+ -4)
+            curr :+ -2
+          })
+          log.update(curr => curr :+ -5)
+          curr :+ (n - 2)
+        })
+        log.update(curr => curr :+ (n - 1))
+      }(owner)
+
+    clickBus.writer.onNext(())
+
+    log.now() shouldBe List(0, -1, -2, -3, -4, -5, 1)
+
+    // --
+
+    clickBus.writer.onNext(())
+
+    log.now() shouldBe List(0, -1, -2, -3, -4, -5, 1, 2, -1, -2, -3, -4, -5, 3)
+
+    Transaction.isClearState shouldBe true
+  }
+
+  it("Errors in transaction code leave a recoverable state") {
+
+    implicit val owner: TestableOwner = new TestableOwner
+
+    val bus = new EventBus[Int]
+    val log = Var[List[Int]](Nil)
+
+    val effects = mutable.Buffer[Effect[Int]]()
+
+    val obs1 = Observer[Int](effects += Effect("obs1", _))
+    val obs2 = Observer[Int](effects += Effect("obs2", _))
+
+    bus.events.addObserver(obs1)
+    bus.events.map(_ * 10).addObserver(obs1)
+
+    bus.events.foreach { num =>
+      if (num % 2 == 0) {
+        new Transaction(_ => {
+          throw new Exception("Random error in transaction")
+        })
+      } else {
+        log.update(_ :+ num)
+      }
+    }
+
+    bus.events.addObserver(obs2)
+    bus.events.map(_ * 10).addObserver(obs2)
+
+    effects shouldBe mutable.Buffer()
+    log.now() shouldBe Nil
+
+    // --
+
+    bus.writer.onNext(1)
+
+    effects shouldBe mutable.Buffer(
+      Effect("obs1", 1),
+      Effect("obs2", 1),
+      Effect("obs1", 10),
+      Effect("obs2", 10)
+    )
+    effects.clear()
+
+    log.now() shouldBe List(1)
+
+    // --
+
+    Try(bus.writer.onNext(2)).isFailure shouldBe true
+
+    effects shouldBe mutable.Buffer(
+      Effect("obs1", 2),
+      Effect("obs2", 2),
+      Effect("obs1", 20),
+      Effect("obs2", 20)
+    )
+    effects.clear()
+
+    log.now() shouldBe List(1)
+
+    // --
+
+    bus.writer.onNext(3)
+
+    effects shouldBe mutable.Buffer(
+      Effect("obs1", 3),
+      Effect("obs2", 3),
+      Effect("obs1", 30),
+      Effect("obs2", 30)
+    )
+    effects.clear()
+
+    log.now() shouldBe List(1, 3)
+
+    // --
+
+    Try(bus.writer.onNext(4)).isFailure shouldBe true
+
+    effects shouldBe mutable.Buffer(
+      Effect("obs1", 4),
+      Effect("obs2", 4),
+      Effect("obs1", 40),
+      Effect("obs2", 40)
+    )
+    effects.clear()
+
+    log.now() shouldBe List(1, 3)
+
+    Transaction.isClearState shouldBe true
+  }
+
+}

--- a/src/test/scala/com/raquo/airstream/errors/SignalErrorSpec.scala
+++ b/src/test/scala/com/raquo/airstream/errors/SignalErrorSpec.scala
@@ -222,7 +222,7 @@ class SignalErrorSpec extends UnitSpec with BeforeAndAfter {
 
     val bus = new EventBus[Int]
 
-    val signalUp = bus.events.toSignal(-1).fold { num =>
+    val signalUp = bus.events.toSignal(-1).foldLeft { num =>
       if (num < 0) {
         throw err1
       } else num
@@ -275,7 +275,7 @@ class SignalErrorSpec extends UnitSpec with BeforeAndAfter {
 
     val bus = new EventBus[Int]
 
-    val signalUp = bus.events.toSignal(-1).foldRecover(tryNum => tryNum.map { num =>
+    val signalUp = bus.events.toSignal(-1).foldLeftRecover(tryNum => tryNum.map { num =>
       if (num < 0) {
         throw err1
       } else num

--- a/src/test/scala/com/raquo/airstream/fixtures/TestableOneTimeOwner.scala
+++ b/src/test/scala/com/raquo/airstream/fixtures/TestableOneTimeOwner.scala
@@ -1,0 +1,10 @@
+package com.raquo.airstream.fixtures
+
+import com.raquo.airstream.ownership.{OneTimeOwner, Subscription}
+
+class TestableOneTimeOwner(onAccessAfterKilled: () => Unit) extends OneTimeOwner(onAccessAfterKilled){
+
+  def _testSubscriptions: List[Subscription] = subscriptions.toList
+
+  override def killSubscriptions(): Unit = super.killSubscriptions()
+}

--- a/src/test/scala/com/raquo/airstream/fixtures/TestableOwner.scala
+++ b/src/test/scala/com/raquo/airstream/fixtures/TestableOwner.scala
@@ -2,11 +2,9 @@ package com.raquo.airstream.fixtures
 
 import com.raquo.airstream.ownership.{Owner, Subscription}
 
-import scala.scalajs.js
-
 class TestableOwner extends Owner {
 
-  def _testSubscriptions: js.Array[Subscription] = subscriptions
+  def _testSubscriptions: List[Subscription] = subscriptions.toList
 
   override def killSubscriptions(): Unit = {
     super.killSubscriptions()

--- a/src/test/scala/com/raquo/airstream/ownership/DynamicOwnerSpec.scala
+++ b/src/test/scala/com/raquo/airstream/ownership/DynamicOwnerSpec.scala
@@ -20,7 +20,7 @@ class DynamicOwnerSpec extends UnitSpec {
     val obs1 = Observer[Int](effects += Effect("obs1", _))
     val obs2 = Observer[Int](effects += Effect("obs2", _))
 
-    val dynOwner = new DynamicOwner
+    val dynOwner = new DynamicOwner(() => fail("Attempted to use permakilled owner!"))
 
     val dynSub1 = DynamicSubscription(dynOwner, owner => bus1.events.addObserver(obs1)(owner))
 

--- a/src/test/scala/com/raquo/airstream/ownership/OwnerSpec.scala
+++ b/src/test/scala/com/raquo/airstream/ownership/OwnerSpec.scala
@@ -1,7 +1,9 @@
 package com.raquo.airstream.ownership
 
 import com.raquo.airstream.UnitSpec
-import com.raquo.airstream.fixtures.{TestableOwner, TestableSubscription}
+import com.raquo.airstream.fixtures.{TestableOneTimeOwner, TestableOwner, TestableSubscription}
+
+import scala.util.Try
 
 class OwnerSpec extends UnitSpec {
 
@@ -12,21 +14,21 @@ class OwnerSpec extends UnitSpec {
     val ts1 = new TestableSubscription(owner)
     val ts2 = new TestableSubscription(owner)
 
-    owner._testSubscriptions.toSeq shouldEqual List(ts1.subscription, ts2.subscription)
+    owner._testSubscriptions shouldEqual List(ts1.subscription, ts2.subscription)
     ts1.killCount shouldBe 0
     ts2.killCount shouldBe 0
 
     owner.killSubscriptions()
 
     // Killing possessions calls kill on each of them exactly once, and then clears the list of possessions
-    owner._testSubscriptions.toSeq shouldEqual Nil
+    owner._testSubscriptions shouldEqual Nil
     ts1.killCount shouldBe 1
     ts2.killCount shouldBe 1
 
     val ts3 = new TestableSubscription(owner)
 
     // Owner still functions as normal even after the killing spree
-    owner._testSubscriptions.toSeq shouldEqual List(ts3.subscription)
+    owner._testSubscriptions shouldEqual List(ts3.subscription)
     ts1.killCount shouldBe 1
     ts2.killCount shouldBe 1
     ts3.killCount shouldBe 0
@@ -43,5 +45,84 @@ class OwnerSpec extends UnitSpec {
     ts3.killCount shouldBe 1
 
     // @TODO[Airstream] Check that killing manually does not result in double-kill
+  }
+
+  it("OneTimeOwner is unusable after it's killed") {
+
+    var errorCallbackCounter = 0
+    var cleanedCounter = 0
+
+    val owner = new TestableOneTimeOwner(() => {
+      errorCallbackCounter += 1
+    })
+
+    val sub1 = new Subscription(owner, cleanup = () => cleanedCounter += 1)
+    val sub2 = new Subscription(owner, cleanup = () => cleanedCounter += 1)
+
+    owner._testSubscriptions shouldBe List(sub1, sub2)
+
+    // --
+
+    owner.killSubscriptions()
+
+    owner._testSubscriptions shouldBe Nil
+    errorCallbackCounter shouldBe 0
+    cleanedCounter shouldBe 2
+
+    cleanedCounter = 0
+
+    // --
+
+    owner.killSubscriptions()
+    errorCallbackCounter shouldBe 0
+    cleanedCounter shouldBe 0
+
+    // --
+
+    val sub3 = new Subscription(owner, cleanup = () => cleanedCounter += 1)
+
+    owner._testSubscriptions shouldBe Nil
+    errorCallbackCounter shouldBe 1
+    cleanedCounter shouldBe 1
+
+    errorCallbackCounter = 0
+    cleanedCounter = 0
+
+    Try(sub3.kill()).isFailure shouldBe true // Can not kill already killed subscription
+  }
+
+  it("OneTimeOwner handles callbacks that throw") {
+
+    var cleanedCounter = 0
+
+    val owner = new TestableOneTimeOwner(() => throw new Exception("OneTimeOwner misused!"))
+
+    val sub1 = new Subscription(owner, cleanup = () => cleanedCounter += 1)
+    val sub2 = new Subscription(owner, cleanup = () => cleanedCounter += 1)
+
+    owner._testSubscriptions shouldBe List(sub1, sub2)
+
+    // --
+
+    owner.killSubscriptions()
+
+    owner._testSubscriptions shouldBe Nil
+    cleanedCounter shouldBe 2
+
+    cleanedCounter = 0
+
+    // --
+
+    owner.killSubscriptions()
+    cleanedCounter shouldBe 0
+
+    // --
+
+    Try(new Subscription(owner, cleanup = () => cleanedCounter += 1)).isFailure shouldBe true
+
+    owner._testSubscriptions shouldBe Nil
+    cleanedCounter shouldBe 1 // verify subscription was cleaned up
+
+    cleanedCounter = 0
   }
 }

--- a/src/test/scala/com/raquo/airstream/ownership/TransferableSubscriptionSpec.scala
+++ b/src/test/scala/com/raquo/airstream/ownership/TransferableSubscriptionSpec.scala
@@ -4,12 +4,16 @@ import com.raquo.airstream.UnitSpec
 
 class TransferableSubscriptionSpec extends UnitSpec {
 
+  private def makeDynamicOwner(): DynamicOwner = {
+    new DynamicOwner(() => fail("Attempted to use permakilled owner!"))
+  }
+
   it("none -> p1.inactive -> p1.activate -> p1.deactivate -> none") {
 
     var activationCounter = 0
     var deactivationCounter = 0
 
-    val parentOwner1 = new DynamicOwner
+    val parentOwner1 = makeDynamicOwner()
 
     // --
 
@@ -56,7 +60,7 @@ class TransferableSubscriptionSpec extends UnitSpec {
     var activationCounter = 0
     var deactivationCounter = 0
 
-    val parentOwner1 = new DynamicOwner
+    val parentOwner1 = makeDynamicOwner()
 
     parentOwner1.activate()
 
@@ -109,9 +113,9 @@ class TransferableSubscriptionSpec extends UnitSpec {
     var activationCounter = 0
     var deactivationCounter = 0
 
-    val parentOwner1 = new DynamicOwner
-    val parentOwner2 = new DynamicOwner
-    val parentOwner3 = new DynamicOwner
+    val parentOwner1 = makeDynamicOwner()
+    val parentOwner2 = makeDynamicOwner()
+    val parentOwner3 = makeDynamicOwner()
 
     parentOwner1.activate()
     parentOwner3.activate()
@@ -172,9 +176,9 @@ class TransferableSubscriptionSpec extends UnitSpec {
     var activationCounter = 0
     var deactivationCounter = 0
 
-    val parentOwner1 = new DynamicOwner
-    val parentOwner2 = new DynamicOwner
-    val parentOwner3 = new DynamicOwner
+    val parentOwner1 = makeDynamicOwner()
+    val parentOwner2 = makeDynamicOwner()
+    val parentOwner3 = makeDynamicOwner()
 
     parentOwner1.activate()
     parentOwner2.activate()

--- a/src/test/scala/com/raquo/airstream/signal/VarSpec.scala
+++ b/src/test/scala/com/raquo/airstream/signal/VarSpec.scala
@@ -231,14 +231,30 @@ class VarSpec extends UnitSpec with BeforeAndAfter {
     // @TODO[API] Figure out if there is an elegant solution that would allow for type inference here
     val result = Try(Var.update(
       x -> ((_: Int) => 4),
-      y -> ((x: Int) => x + 100)
+      y -> ((curr: Int) => curr + 100)
     ))
 
     // Can't update 'x' because it's failed.
     // Both updates will fail because of atomicity. All Vars will retain their previous values.
-    assert(result.isFailure)
     assert(x.tryNow() == Failure(err1))
     assert(y.now() == 300)
+    assert(result.isFailure)
+
+    // --
+
+    // Same as above but ordered differently
+    val result2 = Try(Var.update(
+      y -> ((curr: Int) => curr + 100),
+      x -> ((_: Int) => 4)
+    ))
+
+    // Can't update 'x' because it's failed.
+    // Both updates will fail because of atomicity. All Vars will retain their previous values.
+    assert(x.tryNow() == Failure(err1))
+    assert(y.now() == 300)
+    assert(result2.isFailure)
+
+    // --
 
     Var.tryUpdate(
       x -> ((_: Try[Int]) => Success(5)),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.0-M1"
+version in ThisBuild := "0.11.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.3-SNAPSHOT"
+version in ThisBuild := "0.11.0-M1"


### PR DESCRIPTION
Allegedly fixes #39.

First version available as `0.11.0-M1`. Documentation not updated yet.

I will add more unrelated changes to this branch later.

---

What I did to fix the glitch:

var.update, Var.update and the corresponding try* methods will evaluate the provided `mod` callbacks only when their transaction is executed, not immediately as before. That was obvious, but not nearly enough on its own. The complex part is this:

I changed transaction scheduling logic. Transactions are scheduled when you create a new transaction – e.g. call var.set or var.update or eventbus.writer.onNext – while a transaction is already running, so e.g. inside an `observable.foreach` block. This part didn't change, that's just the definition.

Previously, those scheduled transactions were then executed in the order in which they were scheduled. In this PR I changed this. Instead, if you for example have scheduled transactions B and C while transaction A was running, transaction B will execute after A, but here's what happens after that: if you have scheduled any transactions while B was running, those transactions will execute before transaction C is executed, even though they were scheduled later than C. And this is recursive. This way, transaction B can properly and completely "finish" (even if it requires more transactions), before transaction C, which was intended to go after it, starts executing.

If what I'm saying is not clear, please see the last test in GlitchSpec.scala

I think this new logic makes more sense, and it's no coincidence that it also happens to fix the glitch. The previous approach resulted in surprising and somewhat arbitrary timing behaviour as demonstrated by #39.

---

I published this as a milestone release so that you can test it on your codebase. Especially if you ran into #39, but even if not, this change in behaviour might still affect you if you somehow relied on previous transaction timing. **Please throw out the `delay(0)` / `setTimeout` workarounds when testing, this should work without them.** This branch will become Airstream v0.11.0, so please check this new behaviour and let me know if you needed to fix anything or if it works with no adjustments. All the Laminar tests pass, and my own private codebase works just fine (after a lot of trial and error getting the queue algorithm right) so I'm optimistic.

