### PR TITLE
Make a Signal forget its internal memory when stopped.

### DIFF
--- a/src/main/scala/com/raquo/airstream/signal/Signal.scala
+++ b/src/main/scala/com/raquo/airstream/signal/Signal.scala
@@ -137,6 +137,11 @@ trait Signal[+A] extends Observable[A] {
     super.onStart()
   }
 
+  override protected[this] def onStop(): Unit = {
+    super.onStop()
+    maybeLastSeenCurrentValue = js.undefined
+  }
+
   // @TODO[API] Use pattern match instead when isInstanceOf performance is fixed: https://github.com/scala-js/scala-js/issues/2066
   override protected def onAddedExternalObserver(observer: Observer[A]): Unit = {
     super.onAddedExternalObserver(observer)


### PR DESCRIPTION
Our team came across the issue described in #43. 

We have a Laminar element rendering a value mapped from a Signal: `val fooView = div(child.text <-- fooSignal.map(_.toString))`. However if `fooView` was unmounted and meanwhile the `fooSignal` received updates, when `fooView` is re-mounted it displayed out-of-date values (the latest value it was able to see before being unmounted) and not the current value from `fooSignal`.

I understand this is the expected behaviour, since Airstream signals are lazy which is totally OK!.
However people in our team were expecting that once a Signal gets re-started it should ask their parent
signal for the newest value (just like when first activated).


This branch changes `Signal.onStop` to make it forget its internal memory when all observers have been removed by just reverting `maybeLastSeenCurrentValue` to its original undefined state, causing it
to re-compute the "initialValue" again if the Signal is re-started.

This way, elements rendering values from dependent signals (eg, MapSignal) correctly show the latest
value when re-mounted.

We are currently using this branch from jitpack and all seems to work as expected. However I was not able to run all tests (since I'll have to install yarn and probably other dependencies), but I would like to know if this PR's approach is correct.


Fixes #43
