### PR TITLE
Build: Use github URL instead of local path in SJSIR files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,13 @@ scalacOptions ~= { options: Seq[String] =>
   ))
 }
 
+scalacOptions += {
+  val local = baseDirectory.value.toURI
+  val remote = s"https://raw.githubusercontent.com/raquo/Airstream/${git.gitHeadCommit.value.get}/"
+
+  s"-P:scalajs:mapSourceURI:$local->$remote"
+}
+
 scalacOptions in Test ~= { options: Seq[String] =>
   options.filterNot { o =>
     o.startsWith("-Ywarn-unused") || o.startsWith("-Wunused")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
Maps local file paths to persistent Github URLs in compiled artifacts.

See https://github.com/raquo/Laminar/pull/91 for discussion and more details.