### PR TITLE
Allow Observable extensions in third party packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ I created Airstream because I found existing solutions were not suitable for bui
     * [Websockets](#websockets)
     * [DOM Events](#dom-events)
     * [Custom Event Sources](#custom-event-sources)
-    * [Custom Observables](#custom-observables)
+    * [Extending Observables](#extending-observables)
   * [Sources & Sinks](#sources--sinks)
   * [FRP Glitches](#frp-glitches)
     * [Other Libraries](#other-libraries)
@@ -784,7 +784,7 @@ Let's look at the methods that `CustomStreamSource` makes available to us:
 ```scala
 class CustomSignalSource[A] (
   getInitialValue: => Try[A],
-  makeConfig: (SetCurrentValue[A], GetCurrentValue[A], GetStartIndex, GetIsStarted) => CustomSource.Config,
+  makeConfig: (SetCurrentValue[A], GetCurrentValue[A], GetStartIndex, GetIsStarted) => CustomSource.Config
 )
 ```
 
@@ -793,11 +793,24 @@ class CustomSignalSource[A] (
 Generally signals need to be started in order for their current value to update. Stopped signals generally don't update without listeners, unless they are a `StrictSignal` like `Var#signal`. `CustomSignalSource` is not a `StrictSignal` so there is no expectation for it to keep updating its value when it's stopped. Users should keep listening to signals that they care about.
 
 
-#### Custom Observables
+#### Extending Observables
 
-If you need a custom observable that depends on other Airstream observables, you can subclass EventStream or Signal. It can be intimidating at first, but actually it's pretty easy. Look at the various observables available in Airstream for inspiration, starting with `MapEventStream`.
+If you need a custom observable that depends on another Airstream observable, you can subclass WritableEventStream or WritableSignal. See existing classes for inspiration, such as `MapSignal` and `MapEventStream`.
 
-Note: Observable's `topoRank` field is `protected[airstream]`, so you'll need to override it with a **public** val in your non-airstream subclass. See [#37](https://github.com/raquo/Airstream/issues/37).
+You will likely want to mix in `SingleParentObservable` trait and either `InternalTryObserver` (for signals) or `InternalNextErrorObserver` (for streams). Then you will just need to implement `onTry` (for signals) or `onNext` / `onError` (for streams) methods, which will be triggered when the parent observable emits. In turn, those methods should call `fireValue`, `fireError` or `fireTry` to make your custom observable emit a value. Also, for signals you will need to implement `initivalValue` which you should derive from the parent observable's current value (NOT from the parent observable's `initialValue`).
+
+If you want to put asynchronous logic in your observable, make sure to have a good understanding of Airstream transactions and topoRank, and consult with other asynchronous observables implementations such as `DelayEventStream`.
+
+If your custom observable does not depend on any Airstream observables, e.g. if you're writing a compatibility layer for another streaming library, you generally should be able to use the simpler [Custom Sources](#custom-sources) API.
+
+
+##### Accessing protected members
+
+Some values and methods that you might want to access on observables are `protected`. That means that the compiler will only let you access those values and methods on the same instance. So, you can read `this.topoRank`, but you can't read `parentObservable.topoRank`. To get around this, use the `Protected` object: `Protected.topoRank(parentObservable)`.
+
+Aside from `topoRank`, you will need to access `tryNow()` and `now()` this way, e.g. when implementing a custom signal's `initialValue`. These methods require an implicit evidence of type `Protected`, which is automatically in scope if you're calling these methods from inside your custom observable. You're not supposed to access a signal's current value from the outside, without proving that the signal is running (e.g. by subscribing to it), otherwise you might get a stale value.
+
+Honestly all this "protected" business smells funny to me, but I couldn't figure out a better way to allow third party extensions without making these protected members public.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1335,18 +1335,18 @@ Yes, such an error could have made parts of your application state inconsistent,
 
 #### Airstream's Approach
 
-Airstream aspires to replicate the feel of native exception handling in FRP. However, whereas in imperative code we _want_ Scala to propagate exceptions up the call stack, in Airstream we instead want to propagate errors in observables to their observers and dependent observables.
+Airstream aspires to replicate the feel of native exception handling in FRP. However, whereas in imperative code we typically want to propagate exceptions up the call stack, in Airstream we instead want to propagate errors in observables to their observers and dependent observables.
 
-Think about it this way: in imperative code, you call a function which can throw, and you can either handle it or decide to let your caller handle it, and so on, recursively. In Airstream, you make an observable that depends on another observable which can throw. So you can either handle it, or let any downstream observables or observers handle it.
+Think about it this way: in imperative code, you call a function which can throw, and you can either handle the error or decide to let your caller handle it, and so on, recursively. In Airstream, you make an observable that depends on another observable which can "throw". So you can either handle the error, or let any downstream observables or observers handle it.
 
 This FRP adaptation of classic exception handling is somewhat similar to the approach of Scala.rx, however since Airstream offers a unified reactive system, we have to adjust this basic idea to support event streams as well.
 
-To contrast our approach with conventional streaming libraries, where they see a failed _stream_, we only see a failed _value_, generally expecting the next emitted value to work fine. This is similar to plain Scala exceptions: if a function throws an exception, it does not suddenly become broken forever. You can call it again with perhaps a different value, and it will perhaps not fail that time. Yes, if such an exception produces invalid state, you as a programmer need to address it. Same in Airstream. We give you the tools (more on this below), you do the work, because you're the only one who knows _how_.
+To contrast our approach with conventional streaming libraries: where they see a failed _stream_, we only see a failed _value_, generally expecting the next emitted value to work fine. This is similar to plain Scala exceptions: if a function throws an exception, it does not suddenly become broken forever. You can call it again with perhaps a different value, and it will perhaps not fail that time. Yes, if such an exception produces invalid state, you as a programmer need to address it. Same in Airstream. We give you the tools (more on this below), you do the work, because you're the only one who knows _how_.
 
 We elaborate on the call stack analogy in the subsection [Errors Multiply](#errors-multiply) below.
 
 
-#### Error propagation
+#### Error Propagation
 
 Airstream does not complete or terminate observables on error. Instead, we essentially propagate error values the same way we propagate normal values. Each Observer and InternalObserver has `onNext(A)` and `onError(Throwable)` methods defined, so both observables and observers are capable of accepting error values as inputs.
 

--- a/src/main/scala/com/raquo/airstream/combine/CombineEventStreamN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/CombineEventStreamN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{BaseObservable, EventStream, WritableEventStream}
+import com.raquo.airstream.core.{EventStream, Protected, WritableEventStream}
 
 import scala.util.Try
 
@@ -13,7 +13,7 @@ class CombineEventStreamN[A, Out](
 
   // @TODO[API] Maybe this should throw if parents.isEmpty
 
-  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parents) + 1
+  override protected val topoRank: Int = Protected.maxParentTopoRank(parents) + 1
 
   private[this] val maybeLastParentValues: Array[Option[Try[A]]] = Array.fill(parents.size)(None)
 

--- a/src/main/scala/com/raquo/airstream/combine/CombineEventStreamN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/CombineEventStreamN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{ EventStream, WritableEventStream }
+import com.raquo.airstream.core.{BaseObservable, EventStream, WritableEventStream}
 
 import scala.util.Try
 
@@ -13,7 +13,7 @@ class CombineEventStreamN[A, Out](
 
   // @TODO[API] Maybe this should throw if parents.isEmpty
 
-  override protected[airstream] val topoRank: Int = parents.foldLeft(0)(_ max _.topoRank) + 1
+  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parents) + 1
 
   private[this] val maybeLastParentValues: Array[Option[Try[A]]] = Array.fill(parents.size)(None)
 

--- a/src/main/scala/com/raquo/airstream/combine/CombineSignalN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/CombineSignalN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{ Signal, WritableSignal }
+import com.raquo.airstream.core.{BaseObservable, Signal, WritableSignal}
 
 import scala.util.Try
 
@@ -13,7 +13,7 @@ class CombineSignalN[A, Out](
 
   // @TODO[API] Maybe this should throw if parents.isEmpty
 
-  override protected[airstream] val topoRank: Int = parents.foldLeft(0)(_ max _.topoRank) + 1
+  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parents) + 1
 
   override protected[this] def initialValue: Try[Out] = combinedValue
 

--- a/src/main/scala/com/raquo/airstream/combine/CombineSignalN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/CombineSignalN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{BaseObservable, Signal, WritableSignal}
+import com.raquo.airstream.core.{Protected, Signal, WritableSignal}
 
 import scala.util.Try
 
@@ -13,7 +13,7 @@ class CombineSignalN[A, Out](
 
   // @TODO[API] Maybe this should throw if parents.isEmpty
 
-  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parents) + 1
+  override protected val topoRank: Int = Protected.maxParentTopoRank(parents) + 1
 
   override protected[this] def initialValue: Try[Out] = combinedValue
 

--- a/src/main/scala/com/raquo/airstream/combine/MergeEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/combine/MergeEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
-import com.raquo.airstream.common.{ InternalParentObserver, Observation }
-import com.raquo.airstream.core.{ Observable, SyncObservable, Transaction, WritableEventStream }
+import com.raquo.airstream.common.{InternalParentObserver, Observation}
+import com.raquo.airstream.core.{BaseObservable, Observable, SyncObservable, Transaction, WritableEventStream}
 import com.raquo.airstream.util.JsPriorityQueue
 
 import scala.scalajs.js
@@ -17,15 +17,11 @@ class MergeEventStream[A](
   parents: Iterable[Observable[A]]
 ) extends WritableEventStream[A] with SyncObservable[A] {
 
-  override protected[airstream] val topoRank: Int = {
-    var maxParentRank = 0
-    parents.foreach { parent =>
-      maxParentRank = maxParentRank max parent.topoRank
-    }
-    maxParentRank + 1
-  }
+  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parents) + 1
 
-  private[this] val pendingParentValues: JsPriorityQueue[Observation[A]] = new JsPriorityQueue(_.observable.topoRank)
+  private[this] val pendingParentValues: JsPriorityQueue[Observation[A]] = {
+    new JsPriorityQueue(observation => BaseObservable.topoRank(observation.observable))
+  }
 
   private[this] val parentObservers: js.Array[InternalParentObserver[A]] = js.Array()
 

--- a/src/main/scala/com/raquo/airstream/combine/MergeEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/combine/MergeEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.{InternalParentObserver, Observation}
-import com.raquo.airstream.core.{BaseObservable, Observable, SyncObservable, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{Observable, Protected, SyncObservable, Transaction, WritableEventStream}
 import com.raquo.airstream.util.JsPriorityQueue
 
 import scala.scalajs.js
@@ -17,10 +17,10 @@ class MergeEventStream[A](
   parents: Iterable[Observable[A]]
 ) extends WritableEventStream[A] with SyncObservable[A] {
 
-  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parents) + 1
+  override protected val topoRank: Int = Protected.maxParentTopoRank(parents) + 1
 
   private[this] val pendingParentValues: JsPriorityQueue[Observation[A]] = {
-    new JsPriorityQueue(observation => BaseObservable.topoRank(observation.observable))
+    new JsPriorityQueue(observation => Protected.topoRank(observation.observable))
   }
 
   private[this] val parentObservers: js.Array[InternalParentObserver[A]] = js.Array()

--- a/src/main/scala/com/raquo/airstream/combine/SampleCombineEventStreamN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/SampleCombineEventStreamN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{ EventStream, Signal, Transaction, WritableEventStream }
+import com.raquo.airstream.core.{BaseObservable, EventStream, Signal, Transaction, WritableEventStream}
 
 import scala.util.Try
 
@@ -20,7 +20,7 @@ class SampleCombineEventStreamN[A, Out](
   combinator: Seq[A] => Out
 ) extends WritableEventStream[Out] with CombineObservable[Out] {
 
-  override protected[airstream] val topoRank: Int = (samplingStream +: sampledSignals).foldLeft(0)(_ max _.topoRank) + 1
+  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(samplingStream +: sampledSignals) + 1
 
   private[this] var maybeLastSamplingValue: Option[Try[A]] = None
 

--- a/src/main/scala/com/raquo/airstream/combine/SampleCombineEventStreamN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/SampleCombineEventStreamN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{BaseObservable, EventStream, Signal, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{EventStream, Protected, Signal, Transaction, WritableEventStream}
 
 import scala.util.Try
 
@@ -20,7 +20,7 @@ class SampleCombineEventStreamN[A, Out](
   combinator: Seq[A] => Out
 ) extends WritableEventStream[Out] with CombineObservable[Out] {
 
-  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(samplingStream +: sampledSignals) + 1
+  override protected val topoRank: Int = Protected.maxParentTopoRank(samplingStream +: sampledSignals) + 1
 
   private[this] var maybeLastSamplingValue: Option[Try[A]] = None
 

--- a/src/main/scala/com/raquo/airstream/combine/SampleCombineSignalN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/SampleCombineSignalN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{BaseObservable, Signal, WritableSignal}
+import com.raquo.airstream.core.{Protected, Signal, WritableSignal}
 
 import scala.util.Try
 
@@ -20,7 +20,7 @@ class SampleCombineSignalN[A, Out](
   combinator: Seq[A] => Out
 ) extends WritableSignal[Out] with CombineObservable[Out] {
 
-  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(samplingSignal +: sampledSignals) + 1
+  override protected val topoRank: Int = Protected.maxParentTopoRank(samplingSignal +: sampledSignals) + 1
 
   override protected[this] def initialValue: Try[Out] = combinedValue
 

--- a/src/main/scala/com/raquo/airstream/combine/SampleCombineSignalN.scala
+++ b/src/main/scala/com/raquo/airstream/combine/SampleCombineSignalN.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.combine
 
 import com.raquo.airstream.common.InternalParentObserver
-import com.raquo.airstream.core.{ Signal, WritableSignal }
+import com.raquo.airstream.core.{BaseObservable, Signal, WritableSignal}
 
 import scala.util.Try
 
@@ -20,7 +20,7 @@ class SampleCombineSignalN[A, Out](
   combinator: Seq[A] => Out
 ) extends WritableSignal[Out] with CombineObservable[Out] {
 
-  override protected[airstream] val topoRank: Int = (samplingSignal +: sampledSignals).foldLeft(0)(_ max _.topoRank) + 1
+  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(samplingSignal +: sampledSignals) + 1
 
   override protected[this] def initialValue: Try[Out] = combinedValue
 

--- a/src/main/scala/com/raquo/airstream/common/InternalNextErrorObserver.scala
+++ b/src/main/scala/com/raquo/airstream/common/InternalNextErrorObserver.scala
@@ -7,7 +7,7 @@ import scala.util.Try
 /** Observer that requires you to define `onNext` and `onError` */
 trait InternalNextErrorObserver[A] extends InternalObserver[A] {
 
-  override protected[airstream] final def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
+  override protected final def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
     nextValue.fold(
       onError(_, transaction),
       onNext(_, transaction)

--- a/src/main/scala/com/raquo/airstream/common/InternalParentObserver.scala
+++ b/src/main/scala/com/raquo/airstream/common/InternalParentObserver.scala
@@ -31,11 +31,11 @@ object InternalParentObserver {
 
       override protected[this] val parent: Observable[A] = parentParam
 
-      override protected[airstream] final def onNext(nextValue: A, transaction: Transaction): Unit = {
+      override protected final def onNext(nextValue: A, transaction: Transaction): Unit = {
         onNextParam(nextValue, transaction)
       }
 
-      override protected[airstream] final def onError(nextError: Throwable, transaction: Transaction): Unit = {
+      override protected final def onError(nextError: Throwable, transaction: Transaction): Unit = {
         onErrorParam(nextError, transaction)
       }
     }

--- a/src/main/scala/com/raquo/airstream/common/InternalParentObserver.scala
+++ b/src/main/scala/com/raquo/airstream/common/InternalParentObserver.scala
@@ -19,7 +19,7 @@ trait InternalParentObserver[A] extends InternalObserver[A] {
 
 object InternalParentObserver {
 
-  protected[airstream] def apply[A](
+  def apply[A](
     parent: Observable[A],
     onNext: (A, Transaction) => Unit,
     onError: (Throwable, Transaction) => Unit
@@ -41,7 +41,7 @@ object InternalParentObserver {
     }
   }
 
-  protected[airstream] def fromTry[A](
+  def fromTry[A](
     parent: Observable[A],
     onTry: (Try[A], Transaction) => Unit
   ): InternalParentObserver[A] = {
@@ -51,7 +51,7 @@ object InternalParentObserver {
 
       override protected[this] val parent: Observable[A] = parentParam
 
-      override protected[airstream] final def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
+      override protected final def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
         onTryParam(nextValue, transaction)
       }
     }

--- a/src/main/scala/com/raquo/airstream/common/InternalTryObserver.scala
+++ b/src/main/scala/com/raquo/airstream/common/InternalTryObserver.scala
@@ -6,11 +6,11 @@ import scala.util.{Failure, Success}
 
 trait InternalTryObserver[-A] extends InternalObserver[A] {
 
-  override protected[airstream] final def onNext(nextValue: A, transaction: Transaction): Unit = {
+  override protected final def onNext(nextValue: A, transaction: Transaction): Unit = {
     onTry(Success(nextValue), transaction)
   }
 
-  override protected[airstream] final def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected final def onError(nextError: Throwable, transaction: Transaction): Unit = {
     onTry(Failure(nextError), transaction)
   }
 }

--- a/src/main/scala/com/raquo/airstream/core/BaseObservable.scala
+++ b/src/main/scala/com/raquo/airstream/core/BaseObservable.scala
@@ -29,7 +29,7 @@ trait BaseObservable[+Self[+_] <: Observable[_], +A] extends Source[A] with Name
 
   @inline protected implicit def protectedAccessEvidence: Protected = Protected.protectedAccessEvidence
 
-  /** Note: Use BaseObservable.topoRank(observable) to read another observable's topoRank if needed */
+  /** Note: Use Protected.topoRank(observable) to read another observable's topoRank if needed */
   protected val topoRank: Int
 
 
@@ -159,9 +159,7 @@ trait BaseObservable[+Self[+_] <: Observable[_], +A] extends Source[A] with Name
 
 object BaseObservable {
 
-  def topoRank[O[+_] <: Observable[_]](observable: BaseObservable[O, _]): Int = observable.topoRank
-
-  def maxParentTopoRank[O[+_] <: Observable[_]](parents: Iterable[BaseObservable[O, _]]): Int = {
-    parents.foldLeft(0)((maxRank, parent) => parent.topoRank max maxRank)
+  @inline private[airstream] def topoRank[O[+_] <: Observable[_]](observable: BaseObservable[O, _]): Int = {
+    observable.topoRank
   }
 }

--- a/src/main/scala/com/raquo/airstream/core/BaseObservable.scala
+++ b/src/main/scala/com/raquo/airstream/core/BaseObservable.scala
@@ -27,13 +27,8 @@ import scala.util.Try
   */
 trait BaseObservable[+Self[+_] <: Observable[_], +A] extends Source[A] with Named {
 
-  /** When subclassing Observable **outside of com.raquo.airstream package**, just make this field public:
-    *
-    *     override val topoRank: Int = ???
-    *
-    * "protected[airstream]" will allow this. See https://github.com/raquo/Airstream/issues/37
-    */
-  protected[airstream] val topoRank: Int
+  /** Note: Use BaseObservable.topoRank(observable) to read another observable's topoRank if needed */
+  protected val topoRank: Int
 
 
   /** @param project Note: guarded against exceptions */
@@ -158,4 +153,13 @@ trait BaseObservable[+Self[+_] <: Observable[_], +A] extends Source[A] with Name
     */
   protected def onStop(): Unit = ()
 
+}
+
+object BaseObservable {
+
+  def topoRank[O[+_] <: Observable[_]](observable: BaseObservable[O, _]): Int = observable.topoRank
+
+  def maxParentTopoRank[O[+_] <: Observable[_]](parents: Iterable[BaseObservable[O, _]]): Int = {
+    parents.foldLeft(0)((maxRank, parent) => parent.topoRank max maxRank)
+  }
 }

--- a/src/main/scala/com/raquo/airstream/core/BaseObservable.scala
+++ b/src/main/scala/com/raquo/airstream/core/BaseObservable.scala
@@ -27,6 +27,8 @@ import scala.util.Try
   */
 trait BaseObservable[+Self[+_] <: Observable[_], +A] extends Source[A] with Named {
 
+  @inline protected implicit def protectedAccessEvidence: Protected = Protected.protectedAccessEvidence
+
   /** Note: Use BaseObservable.topoRank(observable) to read another observable's topoRank if needed */
   protected val topoRank: Int
 

--- a/src/main/scala/com/raquo/airstream/core/InternalObserver.scala
+++ b/src/main/scala/com/raquo/airstream/core/InternalObserver.scala
@@ -5,13 +5,13 @@ import scala.util.{Failure, Success, Try}
 trait InternalObserver[-A] {
 
   /** Must not throw */
-  protected[airstream] def onNext(nextValue: A, transaction: Transaction): Unit
+  protected def onNext(nextValue: A, transaction: Transaction): Unit
 
   /** Must not throw */
-  protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit
+  protected def onError(nextError: Throwable, transaction: Transaction): Unit
 
   /** Must not throw */
-  protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit
+  protected def onTry(nextValue: Try[A], transaction: Transaction): Unit
 }
 
 object InternalObserver {
@@ -56,5 +56,29 @@ object InternalObserver {
         onTryParam(nextValue, transaction)
       }
     }
+  }
+
+  @inline private[airstream] def onNext[A](
+    observer: InternalObserver[A],
+    nextValue: A,
+    transaction: Transaction
+  ): Unit = {
+    observer.onNext(nextValue, transaction)
+  }
+
+  @inline private[airstream] def onError(
+    observer: InternalObserver[_],
+    nextError: Throwable,
+    transaction: Transaction
+  ): Unit = {
+    observer.onError(nextError, transaction)
+  }
+
+  @inline private[airstream] def onTry[A](
+    observer: InternalObserver[A],
+    nextValue: Try[A],
+    transaction: Transaction
+  ): Unit = {
+    observer.onTry(nextValue, transaction)
   }
 }

--- a/src/main/scala/com/raquo/airstream/core/Observable.scala
+++ b/src/main/scala/com/raquo/airstream/core/Observable.scala
@@ -37,5 +37,6 @@ object Observable {
     }
   }
 
-  def debugTopoRank(observable: Observable[_]): Int = observable.topoRank
+  // @nc deprecate this
+  def debugTopoRank(observable: Observable[_]): Int = BaseObservable.topoRank(observable)
 }

--- a/src/main/scala/com/raquo/airstream/core/Observable.scala
+++ b/src/main/scala/com/raquo/airstream/core/Observable.scala
@@ -37,6 +37,6 @@ object Observable {
     }
   }
 
-  // @nc deprecate this
-  def debugTopoRank(observable: Observable[_]): Int = BaseObservable.topoRank(observable)
+  @deprecated("0.13.0", "Use `Protected.topoRank` instead of `Observable.debugTopoRank`")
+  def debugTopoRank(observable: Observable[_]): Int = Protected.topoRank(observable)
 }

--- a/src/main/scala/com/raquo/airstream/core/Protected.scala
+++ b/src/main/scala/com/raquo/airstream/core/Protected.scala
@@ -18,5 +18,37 @@ object Protected {
     parents.foldLeft(0)((maxRank, parent) => Protected.topoRank(parent) max maxRank)
   }
 
-  def tryNow[A](signal: Signal[A])(implicit @unused ev: Protected): Try[A] = signal.tryNow()
+  @inline def tryNow[A](signal: Signal[A])(implicit @unused ev: Protected): Try[A] = signal.tryNow()
+
+  @inline def now[A](signal: Signal[A])(implicit @unused ev: Protected): A = signal.now()
+
+  @inline def onNext[A](
+    observer: InternalObserver[A],
+    nextValue: A,
+    transaction: Transaction
+  )(
+    implicit @unused ev: Protected
+  ): Unit = {
+    InternalObserver.onNext(observer, nextValue, transaction)
+  }
+
+  @inline def onError(
+    observer: InternalObserver[_],
+    nextError: Throwable,
+    transaction: Transaction
+  )(
+    implicit @unused ev: Protected
+  ): Unit = {
+    InternalObserver.onError(observer, nextError, transaction)
+  }
+
+  @inline def onTry[A](
+    observer: InternalObserver[A],
+    nextValue: Try[A],
+    transaction: Transaction
+  )(
+    implicit @unused ev: Protected
+  ): Unit = {
+    InternalObserver.onTry(observer, nextValue, transaction)
+  }
 }

--- a/src/main/scala/com/raquo/airstream/core/Protected.scala
+++ b/src/main/scala/com/raquo/airstream/core/Protected.scala
@@ -10,5 +10,13 @@ object Protected {
 
   private[airstream] implicit val protectedAccessEvidence: Protected = new Protected()
 
+  @inline def topoRank[O[+_] <: Observable[_]](observable: BaseObservable[O, _]): Int = {
+    BaseObservable.topoRank(observable)
+  }
+
+  def maxParentTopoRank[O[+_] <: Observable[_]](parents: Iterable[BaseObservable[O, _]]): Int = {
+    parents.foldLeft(0)((maxRank, parent) => Protected.topoRank(parent) max maxRank)
+  }
+
   def tryNow[A](signal: Signal[A])(implicit @unused ev: Protected): Try[A] = signal.tryNow()
 }

--- a/src/main/scala/com/raquo/airstream/core/Protected.scala
+++ b/src/main/scala/com/raquo/airstream/core/Protected.scala
@@ -1,0 +1,14 @@
+package com.raquo.airstream.core
+
+import scala.annotation.{implicitNotFound, unused}
+import scala.util.Try
+
+@implicitNotFound("Implicit instance of Airstream's `Protected` class not found. You're trying to access a method which is designed to only be accessed from inside a BaseObservable subtype.")
+class Protected private ()
+
+object Protected {
+
+  private[airstream] implicit val protectedAccessEvidence: Protected = new Protected()
+
+  def tryNow[A](signal: Signal[A])(implicit @unused ev: Protected): Try[A] = signal.tryNow()
+}

--- a/src/main/scala/com/raquo/airstream/core/Transaction.scala
+++ b/src/main/scala/com/raquo/airstream/core/Transaction.scala
@@ -18,7 +18,9 @@ class Transaction(private[Transaction] val code: Transaction => Any) {
     *
     * Corollary: An Observable that is dequeue-d from here does not synchronously depend on any other pending observables
     */
-  private[airstream] val pendingObservables: JsPriorityQueue[SyncObservable[_]] = new JsPriorityQueue(_.topoRank)
+  private[airstream] val pendingObservables: JsPriorityQueue[SyncObservable[_]] = {
+    new JsPriorityQueue(BaseObservable.topoRank)
+  }
 
   Transaction.pendingTransactions.add(this)
 

--- a/src/main/scala/com/raquo/airstream/core/Transaction.scala
+++ b/src/main/scala/com/raquo/airstream/core/Transaction.scala
@@ -19,7 +19,7 @@ class Transaction(private[Transaction] val code: Transaction => Any) {
     * Corollary: An Observable that is dequeue-d from here does not synchronously depend on any other pending observables
     */
   private[airstream] val pendingObservables: JsPriorityQueue[SyncObservable[_]] = {
-    new JsPriorityQueue(BaseObservable.topoRank)
+    new JsPriorityQueue(Protected.topoRank)
   }
 
   Transaction.pendingTransactions.add(this)

--- a/src/main/scala/com/raquo/airstream/core/WritableEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/WritableEventStream.scala
@@ -21,7 +21,7 @@ trait WritableEventStream[A] extends EventStream[A] with WritableObservable[A] {
     }
 
     internalObservers.foreach { observer =>
-      Protected.onNext(observer, nextValue, transaction)
+      InternalObserver.onNext(observer, nextValue, transaction)
     }
   }
 
@@ -36,7 +36,7 @@ trait WritableEventStream[A] extends EventStream[A] with WritableObservable[A] {
     }
 
     internalObservers.foreach { observer =>
-      Protected.onError(observer, nextError, transaction)
+      InternalObserver.onError(observer, nextError, transaction)
     }
   }
 

--- a/src/main/scala/com/raquo/airstream/core/WritableEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/WritableEventStream.scala
@@ -21,7 +21,7 @@ trait WritableEventStream[A] extends EventStream[A] with WritableObservable[A] {
     }
 
     internalObservers.foreach { observer =>
-      observer.onNext(nextValue, transaction)
+      Protected.onNext(observer, nextValue, transaction)
     }
   }
 
@@ -36,7 +36,7 @@ trait WritableEventStream[A] extends EventStream[A] with WritableObservable[A] {
     }
 
     internalObservers.foreach { observer =>
-      observer.onError(nextError, transaction)
+      Protected.onError(observer, nextError, transaction)
     }
   }
 

--- a/src/main/scala/com/raquo/airstream/core/WritableSignal.scala
+++ b/src/main/scala/com/raquo/airstream/core/WritableSignal.scala
@@ -57,7 +57,7 @@ trait WritableSignal[A] extends Signal[A] with WritableObservable[A] {
       }
 
       internalObservers.foreach { observer =>
-        Protected.onTry(observer, nextValue, transaction)
+        InternalObserver.onTry(observer, nextValue, transaction)
         if (isError && !errorReported) errorReported = true
       }
 

--- a/src/main/scala/com/raquo/airstream/core/WritableSignal.scala
+++ b/src/main/scala/com/raquo/airstream/core/WritableSignal.scala
@@ -57,7 +57,7 @@ trait WritableSignal[A] extends Signal[A] with WritableObservable[A] {
       }
 
       internalObservers.foreach { observer =>
-        observer.onTry(nextValue, transaction)
+        Protected.onTry(observer, nextValue, transaction)
         if (isError && !errorReported) errorReported = true
       }
 

--- a/src/main/scala/com/raquo/airstream/custom/CustomSource.scala
+++ b/src/main/scala/com/raquo/airstream/custom/CustomSource.scala
@@ -20,7 +20,7 @@ trait CustomSource[A] extends WritableObservable[A] {
   // --
 
   /** CustomSource is intended for observables that don't synchronously depend on other observables. */
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   protected[this] var startIndex: StartIndex = 0
 

--- a/src/main/scala/com/raquo/airstream/debug/DebuggableObservable.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggableObservable.scala
@@ -1,6 +1,6 @@
 package com.raquo.airstream.debug
 
-import com.raquo.airstream.core.{Observable, BaseObservable}
+import com.raquo.airstream.core.{BaseObservable, Observable, Protected}
 import com.raquo.airstream.util.always
 import org.scalajs.dom
 
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success, Try}
 class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseObservable[Self, A]) {
 
   /** Return the observable's topoRank. This does not affect the observable in any way. */
-  def debugTopoRank: Int = BaseObservable.topoRank(observable)
+  def debugTopoRank: Int = Protected.topoRank(observable)
 
   /** Create a new observable that listens to the original, and
     * set the displayName of the new observable.
@@ -36,7 +36,7 @@ class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseOb
     * the "foo" displayName of `stream` itself.
     */
   def debugWithName(displayName: String): Self[A] = {
-    val emptyDebugger = Debugger(BaseObservable.topoRank(observable))
+    val emptyDebugger = Debugger(Protected.topoRank(observable))
     observable.debugWith(emptyDebugger).setDisplayName(displayName)
   }
 
@@ -45,7 +45,7 @@ class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseOb
   /** Execute fn on every emitted event or error */
   def debugSpy(fn: Try[A] => Unit): Self[A] = {
     val debugger = Debugger(
-      BaseObservable.topoRank(observable),
+      Protected.topoRank(observable),
       onFire = fn
     )
     observable.debugWith(debugger)
@@ -73,8 +73,8 @@ class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseOb
     */
   def debugSpyLifecycle(startFn: Int => Unit, stopFn: () => Unit): Self[A] = {
     val debugger = Debugger(
-      BaseObservable.topoRank(observable),
-      onStart = () => startFn(BaseObservable.topoRank(observable)),
+      Protected.topoRank(observable),
+      onStart = () => startFn(Protected.topoRank(observable)),
       onStop = stopFn
     )
     observable.debugWith(debugger)

--- a/src/main/scala/com/raquo/airstream/debug/DebuggableObservable.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggableObservable.scala
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success, Try}
 class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseObservable[Self, A]) {
 
   /** Return the observable's topoRank. This does not affect the observable in any way. */
-  def debugTopoRank: Int = observable.topoRank
+  def debugTopoRank: Int = BaseObservable.topoRank(observable)
 
   /** Create a new observable that listens to the original, and
     * set the displayName of the new observable.
@@ -36,7 +36,7 @@ class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseOb
     * the "foo" displayName of `stream` itself.
     */
   def debugWithName(displayName: String): Self[A] = {
-    val emptyDebugger = Debugger(observable.topoRank)
+    val emptyDebugger = Debugger(BaseObservable.topoRank(observable))
     observable.debugWith(emptyDebugger).setDisplayName(displayName)
   }
 
@@ -45,7 +45,7 @@ class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseOb
   /** Execute fn on every emitted event or error */
   def debugSpy(fn: Try[A] => Unit): Self[A] = {
     val debugger = Debugger(
-      observable.topoRank,
+      BaseObservable.topoRank(observable),
       onFire = fn
     )
     observable.debugWith(debugger)
@@ -73,8 +73,8 @@ class DebuggableObservable[Self[+_] <: Observable[_], +A](val observable: BaseOb
     */
   def debugSpyLifecycle(startFn: Int => Unit, stopFn: () => Unit): Self[A] = {
     val debugger = Debugger(
-      observable.topoRank,
-      onStart = () => startFn(observable.topoRank),
+      BaseObservable.topoRank(observable),
+      onStart = () => startFn(BaseObservable.topoRank(observable)),
       onStop = stopFn
     )
     observable.debugWith(debugger)

--- a/src/main/scala/com/raquo/airstream/debug/DebuggableSignal.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggableSignal.scala
@@ -1,6 +1,6 @@
 package com.raquo.airstream.debug
 
-import com.raquo.airstream.core.Signal
+import com.raquo.airstream.core.{BaseObservable, Signal}
 import com.raquo.airstream.util.always
 
 import scala.scalajs.js
@@ -22,7 +22,7 @@ class DebuggableSignal[+A](override val observable: Signal[A]) extends Debuggabl
 
   /** Execute fn when signal is evaluating its initial value */
   def debugSpyInitialEval(fn: Try[A] => Unit): Signal[A] = {
-    val debugger = Debugger(observable.topoRank, onInitialEval = fn)
+    val debugger = Debugger(BaseObservable.topoRank(observable), onInitialEval = fn)
     observable.debugWith(debugger)
   }
 

--- a/src/main/scala/com/raquo/airstream/debug/DebuggableSignal.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggableSignal.scala
@@ -1,6 +1,6 @@
 package com.raquo.airstream.debug
 
-import com.raquo.airstream.core.{BaseObservable, Signal}
+import com.raquo.airstream.core.{Protected, Signal}
 import com.raquo.airstream.util.always
 
 import scala.scalajs.js
@@ -22,7 +22,7 @@ class DebuggableSignal[+A](override val observable: Signal[A]) extends Debuggabl
 
   /** Execute fn when signal is evaluating its initial value */
   def debugSpyInitialEval(fn: Try[A] => Unit): Signal[A] = {
-    val debugger = Debugger(BaseObservable.topoRank(observable), onInitialEval = fn)
+    val debugger = Debugger(Protected.topoRank(observable), onInitialEval = fn)
     observable.debugWith(debugger)
   }
 

--- a/src/main/scala/com/raquo/airstream/debug/DebuggerEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggerEventStream.scala
@@ -32,7 +32,7 @@ class DebuggerEventStream[A](
     debugOnStop()
   }
 
-  override protected[airstream] def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
     fireTry(nextParentValue, transaction)
   }
 }

--- a/src/main/scala/com/raquo/airstream/debug/DebuggerEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggerEventStream.scala
@@ -1,6 +1,6 @@
 package com.raquo.airstream.debug
 
-import com.raquo.airstream.core.{BaseObservable, EventStream, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{EventStream, Protected, Transaction, WritableEventStream}
 
 import scala.util.{Failure, Success, Try}
 
@@ -10,7 +10,7 @@ class DebuggerEventStream[A](
   override protected val debugger: Debugger[A]
 ) extends WritableEventStream[A] with DebuggerObservable[A] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   override protected[this] def fireValue(nextValue: A, transaction: Transaction): Unit = {
     debugFireTry(Success(nextValue))

--- a/src/main/scala/com/raquo/airstream/debug/DebuggerEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggerEventStream.scala
@@ -1,6 +1,6 @@
 package com.raquo.airstream.debug
 
-import com.raquo.airstream.core.{EventStream, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{BaseObservable, EventStream, Transaction, WritableEventStream}
 
 import scala.util.{Failure, Success, Try}
 
@@ -10,7 +10,7 @@ class DebuggerEventStream[A](
   override protected val debugger: Debugger[A]
 ) extends WritableEventStream[A] with DebuggerObservable[A] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   override protected[this] def fireValue(nextValue: A, transaction: Transaction): Unit = {
     debugFireTry(Success(nextValue))

--- a/src/main/scala/com/raquo/airstream/debug/DebuggerSignal.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggerSignal.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.debug
 
 import com.raquo.airstream.core.AirstreamError.DebugError
-import com.raquo.airstream.core.{AirstreamError, BaseObservable, Signal, Transaction, WritableSignal}
+import com.raquo.airstream.core.{AirstreamError, Protected, Signal, Transaction, WritableSignal}
 
 import scala.util.Try
 
@@ -11,7 +11,7 @@ class DebuggerSignal[A](
   override protected val debugger: Debugger[A]
 ) extends WritableSignal[A] with DebuggerObservable[A] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   override protected[this] def initialValue: Try[A] = {
     val initial = parent.tryNow()

--- a/src/main/scala/com/raquo/airstream/debug/DebuggerSignal.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggerSignal.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.debug
 
 import com.raquo.airstream.core.AirstreamError.DebugError
-import com.raquo.airstream.core.{ AirstreamError, Signal, Transaction, WritableSignal }
+import com.raquo.airstream.core.{AirstreamError, BaseObservable, Signal, Transaction, WritableSignal}
 
 import scala.util.Try
 
@@ -11,7 +11,7 @@ class DebuggerSignal[A](
   override protected val debugger: Debugger[A]
 ) extends WritableSignal[A] with DebuggerObservable[A] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   override protected[this] def initialValue: Try[A] = {
     val initial = parent.tryNow()

--- a/src/main/scala/com/raquo/airstream/debug/DebuggerSignal.scala
+++ b/src/main/scala/com/raquo/airstream/debug/DebuggerSignal.scala
@@ -40,7 +40,7 @@ class DebuggerSignal[A](
     debugOnStop()
   }
 
-  override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
     fireTry(nextValue, transaction)
   }
 }

--- a/src/main/scala/com/raquo/airstream/eventbus/EventBusStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/EventBusStream.scala
@@ -32,7 +32,7 @@ class EventBusStream[A] private[eventbus] () extends WritableEventStream[A] with
   }
 
   /** @param ignoredTransaction normally EventBus emits all events in a new transaction, so it ignores whatever is provided. */
-  override protected[airstream] def onNext(nextValue: A, ignoredTransaction: Transaction): Unit = {
+  override protected def onNext(nextValue: A, ignoredTransaction: Transaction): Unit = {
     //dom.console.log(s">>>>WBS.onNext($nextValue): isStarted=$isStarted")
     //dom.console.log(sources)
 
@@ -55,7 +55,7 @@ class EventBusStream[A] private[eventbus] () extends WritableEventStream[A] with
     fireError(nextError, sharedTransaction)
   }
 
-  override protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected def onError(nextError: Throwable, transaction: Transaction): Unit = {
     new Transaction(fireError(nextError, _))
   }
 

--- a/src/main/scala/com/raquo/airstream/eventbus/EventBusStream.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/EventBusStream.scala
@@ -12,7 +12,7 @@ class EventBusStream[A] private[eventbus] () extends WritableEventStream[A] with
   /** Made more public to allow usage from WriteBus */
   override protected[eventbus] def isStarted: Boolean = super.isStarted
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   @inline private[eventbus] def addSource(sourceStream: EventStream[A]): Unit = {
     sourceStreams.push(sourceStream)

--- a/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
@@ -1,6 +1,6 @@
 package com.raquo.airstream.eventbus
 
-import com.raquo.airstream.core.{EventStream, Observer, Transaction}
+import com.raquo.airstream.core.{EventStream, Observer, Protected, Transaction}
 import com.raquo.airstream.ownership.{Owner, Subscription}
 import com.raquo.airstream.util.hasDuplicateTupleKeys
 
@@ -44,7 +44,7 @@ class WriteBus[A] extends Observer[A] {
   override def onNext(nextValue: A): Unit = {
     if (stream.isStarted) { // important check
       // @TODO[Integrity] We rely on the knowledge that EventBusStream discards the transaction it's given. Laaaame
-      stream.onNext(nextValue, ignoredTransaction = null)
+      Protected.onNext(stream, nextValue, transaction = null)
     }
     // else {
     //   println(">>>> WriteBus.onNext called, but stream is not started!")
@@ -54,7 +54,7 @@ class WriteBus[A] extends Observer[A] {
   override def onError(nextError: Throwable): Unit = {
     if (stream.isStarted) {
       // @TODO[Integrity] We rely on the knowledge that EventBusStream discards the transaction it's given. Laaaame
-      stream.onError(nextError, transaction = null)
+      Protected.onError(stream, nextError, transaction = null)
     }
   }
 

--- a/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
+++ b/src/main/scala/com/raquo/airstream/eventbus/WriteBus.scala
@@ -1,6 +1,6 @@
 package com.raquo.airstream.eventbus
 
-import com.raquo.airstream.core.{EventStream, Observer, Protected, Transaction}
+import com.raquo.airstream.core.{EventStream, InternalObserver, Observer, Transaction}
 import com.raquo.airstream.ownership.{Owner, Subscription}
 import com.raquo.airstream.util.hasDuplicateTupleKeys
 
@@ -44,7 +44,7 @@ class WriteBus[A] extends Observer[A] {
   override def onNext(nextValue: A): Unit = {
     if (stream.isStarted) { // important check
       // @TODO[Integrity] We rely on the knowledge that EventBusStream discards the transaction it's given. Laaaame
-      Protected.onNext(stream, nextValue, transaction = null)
+      InternalObserver.onNext(stream, nextValue, transaction = null)
     }
     // else {
     //   println(">>>> WriteBus.onNext called, but stream is not started!")
@@ -54,7 +54,7 @@ class WriteBus[A] extends Observer[A] {
   override def onError(nextError: Throwable): Unit = {
     if (stream.isStarted) {
       // @TODO[Integrity] We rely on the knowledge that EventBusStream discards the transaction it's given. Laaaame
-      Protected.onError(stream, nextError, transaction = null)
+      InternalObserver.onError(stream, nextError, transaction = null)
     }
   }
 

--- a/src/main/scala/com/raquo/airstream/flatten/ConcurrentEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/ConcurrentEventStream.scala
@@ -50,11 +50,11 @@ class ConcurrentEventStream[A](
     super.onStop()
   }
 
-  override protected[airstream] def onNext(nextStream: EventStream[A], transaction: Transaction): Unit = {
+  override protected def onNext(nextStream: EventStream[A], transaction: Transaction): Unit = {
     addStream(nextStream)
   }
 
-  override protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected def onError(nextError: Throwable, transaction: Transaction): Unit = {
     fireError(nextError, transaction)
   }
 

--- a/src/main/scala/com/raquo/airstream/flatten/ConcurrentEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/ConcurrentEventStream.scala
@@ -26,7 +26,7 @@ class ConcurrentEventStream[A](
     onError = (nextError, _) => new Transaction(fireError(nextError, _))
   )
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   override protected[this] def onStart(): Unit = {
     parent match {

--- a/src/main/scala/com/raquo/airstream/flatten/ConcurrentFutureStream.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/ConcurrentFutureStream.scala
@@ -27,7 +27,7 @@ class ConcurrentFutureStream[A](
 
   private[this] var lastEmittedValueIndex: Int = 0
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   override protected[airstream] def onNext(nextFuture: Future[A], transaction: Transaction): Unit = {
     lastFutureIndex += 1

--- a/src/main/scala/com/raquo/airstream/flatten/ConcurrentFutureStream.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/ConcurrentFutureStream.scala
@@ -29,7 +29,7 @@ class ConcurrentFutureStream[A](
 
   override protected val topoRank: Int = 1
 
-  override protected[airstream] def onNext(nextFuture: Future[A], transaction: Transaction): Unit = {
+  override protected def onNext(nextFuture: Future[A], transaction: Transaction): Unit = {
     lastFutureIndex += 1
     val nextFutureIndex = lastFutureIndex
     if (!nextFuture.isCompleted || emitIfFutureCompleted) {
@@ -44,7 +44,7 @@ class ConcurrentFutureStream[A](
     }
   }
 
-  override protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected def onError(nextError: Throwable, transaction: Transaction): Unit = {
     lastFutureIndex += 1
     val nextFutureIndex = lastFutureIndex
     if (!dropPreviousValues || (nextFutureIndex > lastEmittedValueIndex)) {

--- a/src/main/scala/com/raquo/airstream/flatten/SwitchEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/SwitchEventStream.scala
@@ -33,7 +33,7 @@ class SwitchEventStream[I, O](
   makeStream: I => EventStream[O]
 ) extends WritableEventStream[O] with SingleParentObservable[I, O] with InternalNextErrorObserver[I] {
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   private[this] var maybeCurrentEventStream: js.UndefOr[Try[EventStream[O]]] = parent match {
     case signal: Signal[I @unchecked] => signal.tryNow().map(makeStream)

--- a/src/main/scala/com/raquo/airstream/flatten/SwitchEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/SwitchEventStream.scala
@@ -51,7 +51,7 @@ class SwitchEventStream[I, O](
     }
   )
 
-  override protected[airstream] def onNext(nextValue: I, transaction: Transaction): Unit = {
+  override protected def onNext(nextValue: I, transaction: Transaction): Unit = {
     val nextStream = makeStream(nextValue)
     val isSameStream = maybeCurrentEventStream.exists { currentStream =>
       currentStream.isSuccess && (currentStream.get eq nextStream)
@@ -64,7 +64,7 @@ class SwitchEventStream[I, O](
     }
   }
 
-  override protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected def onError(nextError: Throwable, transaction: Transaction): Unit = {
     removeInternalObserverFromCurrentEventStream()
     maybeCurrentEventStream = Failure(nextError)
     fireError(nextError, transaction)

--- a/src/main/scala/com/raquo/airstream/flatten/SwitchSignal.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/SwitchSignal.scala
@@ -31,7 +31,7 @@ class SwitchSignal[A](
     }
   )
 
-  override protected[airstream] def onTry(nextSignalTry: Try[Signal[A]], transaction: Transaction): Unit = {
+  override protected def onTry(nextSignalTry: Try[Signal[A]], transaction: Transaction): Unit = {
     val isSameSignal = nextSignalTry.isSuccess && nextSignalTry == currentSignalTry
     if (!isSameSignal) {
       removeInternalObserverFromCurrentSignal()

--- a/src/main/scala/com/raquo/airstream/flatten/SwitchSignal.scala
+++ b/src/main/scala/com/raquo/airstream/flatten/SwitchSignal.scala
@@ -18,7 +18,7 @@ class SwitchSignal[A](
   override protected[this] val parent: Signal[Signal[A]]
 ) extends WritableSignal[A] with SingleParentObservable[Signal[A], A] with InternalTryObserver[Signal[A]] {
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   override protected def initialValue: Try[A] = parent.tryNow().flatMap(_.tryNow())
 

--- a/src/main/scala/com/raquo/airstream/misc/FilterEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/misc/FilterEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.misc
 
-import com.raquo.airstream.common.{ InternalNextErrorObserver, SingleParentObservable }
-import com.raquo.airstream.core.{ EventStream, Transaction, WritableEventStream }
+import com.raquo.airstream.common.{InternalNextErrorObserver, SingleParentObservable}
+import com.raquo.airstream.core.{BaseObservable, EventStream, Transaction, WritableEventStream}
 
 import scala.util.Try
 
@@ -17,7 +17,7 @@ class FilterEventStream[A](
   passes: A => Boolean
 ) extends WritableEventStream[A] with SingleParentObservable[A, A] with InternalNextErrorObserver[A] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   override protected[airstream] def onNext(nextParentValue: A, transaction: Transaction): Unit = {
     // @TODO[Performance] Can / should we replace internal Try()-s with try-catch blocks?

--- a/src/main/scala/com/raquo/airstream/misc/FilterEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/misc/FilterEventStream.scala
@@ -19,7 +19,7 @@ class FilterEventStream[A](
 
   override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
-  override protected[airstream] def onNext(nextParentValue: A, transaction: Transaction): Unit = {
+  override protected def onNext(nextParentValue: A, transaction: Transaction): Unit = {
     // @TODO[Performance] Can / should we replace internal Try()-s with try-catch blocks?
     Try(passes(nextParentValue)).fold(
       onError(_, transaction),
@@ -27,7 +27,7 @@ class FilterEventStream[A](
     )
   }
 
-  override protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected def onError(nextError: Throwable, transaction: Transaction): Unit = {
     fireError(nextError, transaction)
   }
 }

--- a/src/main/scala/com/raquo/airstream/misc/FilterEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/misc/FilterEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.misc
 
 import com.raquo.airstream.common.{InternalNextErrorObserver, SingleParentObservable}
-import com.raquo.airstream.core.{BaseObservable, EventStream, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{EventStream, Protected, Transaction, WritableEventStream}
 
 import scala.util.Try
 
@@ -17,7 +17,7 @@ class FilterEventStream[A](
   passes: A => Boolean
 ) extends WritableEventStream[A] with SingleParentObservable[A, A] with InternalNextErrorObserver[A] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   override protected[airstream] def onNext(nextParentValue: A, transaction: Transaction): Unit = {
     // @TODO[Performance] Can / should we replace internal Try()-s with try-catch blocks?

--- a/src/main/scala/com/raquo/airstream/misc/FoldLeftSignal.scala
+++ b/src/main/scala/com/raquo/airstream/misc/FoldLeftSignal.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.misc
 
-import com.raquo.airstream.common.{ InternalTryObserver, SingleParentObservable }
-import com.raquo.airstream.core.{ Observable, Transaction, WritableSignal }
+import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
+import com.raquo.airstream.core.{BaseObservable, Observable, Transaction, WritableSignal}
 
 import scala.util.Try
 
@@ -19,7 +19,7 @@ class FoldLeftSignal[A, B](
   fn: (Try[B], Try[A]) => Try[B]
 ) extends WritableSignal[B] with SingleParentObservable[A, B] with InternalTryObserver[A] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   override protected[airstream] def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
     fireTry(fn(tryNow(), nextParentValue), transaction)

--- a/src/main/scala/com/raquo/airstream/misc/FoldLeftSignal.scala
+++ b/src/main/scala/com/raquo/airstream/misc/FoldLeftSignal.scala
@@ -21,7 +21,7 @@ class FoldLeftSignal[A, B](
 
   override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
-  override protected[airstream] def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
     fireTry(fn(tryNow(), nextParentValue), transaction)
   }
 

--- a/src/main/scala/com/raquo/airstream/misc/FoldLeftSignal.scala
+++ b/src/main/scala/com/raquo/airstream/misc/FoldLeftSignal.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.misc
 
 import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
-import com.raquo.airstream.core.{BaseObservable, Observable, Transaction, WritableSignal}
+import com.raquo.airstream.core.{Observable, Protected, Transaction, WritableSignal}
 
 import scala.util.Try
 
@@ -19,7 +19,7 @@ class FoldLeftSignal[A, B](
   fn: (Try[B], Try[A]) => Try[B]
 ) extends WritableSignal[B] with SingleParentObservable[A, B] with InternalTryObserver[A] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   override protected[airstream] def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
     fireTry(fn(tryNow(), nextParentValue), transaction)

--- a/src/main/scala/com/raquo/airstream/misc/MapEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/misc/MapEventStream.scala
@@ -28,14 +28,14 @@ class MapEventStream[I, O](
 
   override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
-  override protected[airstream] def onNext(nextParentValue: I, transaction: Transaction): Unit = {
+  override protected def onNext(nextParentValue: I, transaction: Transaction): Unit = {
     Try(project(nextParentValue)).fold(
       onError(_, transaction),
       fireValue(_, transaction)
     )
   }
 
-  override protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected def onError(nextError: Throwable, transaction: Transaction): Unit = {
     recover.fold(
       // if no `recover` specified, fire original error
       fireError(nextError, transaction))(

--- a/src/main/scala/com/raquo/airstream/misc/MapEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/misc/MapEventStream.scala
@@ -2,7 +2,7 @@ package com.raquo.airstream.misc
 
 import com.raquo.airstream.common.{InternalNextErrorObserver, SingleParentObservable}
 import com.raquo.airstream.core.AirstreamError.ErrorHandlingError
-import com.raquo.airstream.core.{BaseObservable, Observable, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{Observable, Protected, Transaction, WritableEventStream}
 
 import scala.util.Try
 
@@ -26,7 +26,7 @@ class MapEventStream[I, O](
   recover: Option[PartialFunction[Throwable, Option[O]]]
 ) extends WritableEventStream[O] with SingleParentObservable[I, O] with InternalNextErrorObserver[I] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   override protected[airstream] def onNext(nextParentValue: I, transaction: Transaction): Unit = {
     Try(project(nextParentValue)).fold(

--- a/src/main/scala/com/raquo/airstream/misc/MapEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/misc/MapEventStream.scala
@@ -1,8 +1,8 @@
 package com.raquo.airstream.misc
 
-import com.raquo.airstream.common.{ InternalNextErrorObserver, SingleParentObservable }
+import com.raquo.airstream.common.{InternalNextErrorObserver, SingleParentObservable}
 import com.raquo.airstream.core.AirstreamError.ErrorHandlingError
-import com.raquo.airstream.core.{ Observable, Transaction, WritableEventStream }
+import com.raquo.airstream.core.{BaseObservable, Observable, Transaction, WritableEventStream}
 
 import scala.util.Try
 
@@ -26,7 +26,7 @@ class MapEventStream[I, O](
   recover: Option[PartialFunction[Throwable, Option[O]]]
 ) extends WritableEventStream[O] with SingleParentObservable[I, O] with InternalNextErrorObserver[I] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   override protected[airstream] def onNext(nextParentValue: I, transaction: Transaction): Unit = {
     Try(project(nextParentValue)).fold(

--- a/src/main/scala/com/raquo/airstream/misc/MapSignal.scala
+++ b/src/main/scala/com/raquo/airstream/misc/MapSignal.scala
@@ -1,10 +1,10 @@
 package com.raquo.airstream.misc
 
-import com.raquo.airstream.common.{ InternalTryObserver, SingleParentObservable }
+import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
 import com.raquo.airstream.core.AirstreamError.ErrorHandlingError
-import com.raquo.airstream.core.{ Signal, Transaction, WritableSignal }
+import com.raquo.airstream.core.{BaseObservable, Signal, Transaction, WritableSignal}
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 // @TODO[Elegance] Is this right that we shoved .recover into Map observables? Maybe it deserves its own class? But it's so many classes...
 
@@ -24,7 +24,7 @@ class MapSignal[I, O](
   protected[this] val recover: Option[PartialFunction[Throwable, Option[O]]]
 ) extends WritableSignal[O] with SingleParentObservable[I, O] with InternalTryObserver[I] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   override protected[airstream] def onTry(nextParentValue: Try[I], transaction: Transaction): Unit = {
     nextParentValue.fold(

--- a/src/main/scala/com/raquo/airstream/misc/MapSignal.scala
+++ b/src/main/scala/com/raquo/airstream/misc/MapSignal.scala
@@ -2,7 +2,7 @@ package com.raquo.airstream.misc
 
 import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
 import com.raquo.airstream.core.AirstreamError.ErrorHandlingError
-import com.raquo.airstream.core.{BaseObservable, Signal, Transaction, WritableSignal}
+import com.raquo.airstream.core.{Protected, Signal, Transaction, WritableSignal}
 
 import scala.util.{Failure, Success, Try}
 
@@ -24,7 +24,7 @@ class MapSignal[I, O](
   protected[this] val recover: Option[PartialFunction[Throwable, Option[O]]]
 ) extends WritableSignal[O] with SingleParentObservable[I, O] with InternalTryObserver[I] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   override protected[airstream] def onTry(nextParentValue: Try[I], transaction: Transaction): Unit = {
     nextParentValue.fold(

--- a/src/main/scala/com/raquo/airstream/misc/MapSignal.scala
+++ b/src/main/scala/com/raquo/airstream/misc/MapSignal.scala
@@ -26,7 +26,7 @@ class MapSignal[I, O](
 
   override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
-  override protected[airstream] def onTry(nextParentValue: Try[I], transaction: Transaction): Unit = {
+  override protected def onTry(nextParentValue: Try[I], transaction: Transaction): Unit = {
     nextParentValue.fold(
       nextError => recover.fold(
         // if no `recover` specified, fire original error

--- a/src/main/scala/com/raquo/airstream/split/SignalFromEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/split/SignalFromEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.split
 
 import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
-import com.raquo.airstream.core.{BaseObservable, EventStream, Transaction, WritableSignal}
+import com.raquo.airstream.core.{EventStream, Protected, Transaction, WritableSignal}
 
 import scala.util.Try
 
@@ -10,7 +10,7 @@ class SignalFromEventStream[A](
   lazyInitialValue: => Try[A]
 ) extends WritableSignal[A] with SingleParentObservable[A, A] with InternalTryObserver[A] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   override protected def initialValue: Try[A] = lazyInitialValue
 

--- a/src/main/scala/com/raquo/airstream/split/SignalFromEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/split/SignalFromEventStream.scala
@@ -14,7 +14,7 @@ class SignalFromEventStream[A](
 
   override protected def initialValue: Try[A] = lazyInitialValue
 
-  override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
     fireTry(nextValue, transaction)
   }
 }

--- a/src/main/scala/com/raquo/airstream/split/SignalFromEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/split/SignalFromEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.split
 
-import com.raquo.airstream.common.{ InternalTryObserver, SingleParentObservable }
-import com.raquo.airstream.core.{ EventStream, Transaction, WritableSignal }
+import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
+import com.raquo.airstream.core.{BaseObservable, EventStream, Transaction, WritableSignal}
 
 import scala.util.Try
 
@@ -10,7 +10,7 @@ class SignalFromEventStream[A](
   lazyInitialValue: => Try[A]
 ) extends WritableSignal[A] with SingleParentObservable[A, A] with InternalTryObserver[A] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   override protected def initialValue: Try[A] = lazyInitialValue
 

--- a/src/main/scala/com/raquo/airstream/split/SplitEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/split/SplitEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.split
 
-import com.raquo.airstream.common.{ InternalNextErrorObserver, SingleParentObservable }
-import com.raquo.airstream.core.{ EventStream, Signal, Transaction, WritableEventStream }
+import com.raquo.airstream.common.{InternalNextErrorObserver, SingleParentObservable}
+import com.raquo.airstream.core.{BaseObservable, EventStream, Signal, Transaction, WritableEventStream}
 
 import scala.collection.mutable
 import scala.util.Try
@@ -24,7 +24,7 @@ class SplitEventStream[M[_], Input, Output, Key](
   splittable: Splittable[M]
 ) extends WritableEventStream[M[Output]] with SingleParentObservable[M[Input], M[Output]] with InternalNextErrorObserver[M[Input]] {
 
-  override protected[airstream] val topoRank: Int = parent.topoRank + 1
+  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
   private[this] var memoized: Map[Key, (Input, Output)] = Map.empty
 

--- a/src/main/scala/com/raquo/airstream/split/SplitEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/split/SplitEventStream.scala
@@ -33,11 +33,11 @@ class SplitEventStream[M[_], Input, Output, Key](
     super.onStop()
   }
 
-  override protected[airstream] def onNext(nextInputs: M[Input], transaction: Transaction): Unit = {
+  override protected def onNext(nextInputs: M[Input], transaction: Transaction): Unit = {
     fireValue(memoizedProject(nextInputs), transaction)
   }
 
-  override protected[airstream] def onError(nextError: Throwable, transaction: Transaction): Unit = {
+  override protected def onError(nextError: Throwable, transaction: Transaction): Unit = {
     fireError(nextError, transaction)
   }
 

--- a/src/main/scala/com/raquo/airstream/split/SplitEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/split/SplitEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.split
 
 import com.raquo.airstream.common.{InternalNextErrorObserver, SingleParentObservable}
-import com.raquo.airstream.core.{BaseObservable, EventStream, Signal, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{EventStream, Protected, Signal, Transaction, WritableEventStream}
 
 import scala.collection.mutable
 import scala.util.Try
@@ -24,7 +24,7 @@ class SplitEventStream[M[_], Input, Output, Key](
   splittable: Splittable[M]
 ) extends WritableEventStream[M[Output]] with SingleParentObservable[M[Input], M[Output]] with InternalNextErrorObserver[M[Input]] {
 
-  override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+  override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
   private[this] var memoized: Map[Key, (Input, Output)] = Map.empty
 

--- a/src/main/scala/com/raquo/airstream/state/DerivedVarSignal.scala
+++ b/src/main/scala/com/raquo/airstream/state/DerivedVarSignal.scala
@@ -16,7 +16,7 @@ class DerivedVarSignal[A, B](
   recover = None
 ) with OwnedSignal[B] {
 
-  override protected[airstream] def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextParentValue: Try[A], transaction: Transaction): Unit = {
     super.onTry(nextParentValue, transaction)
   }
 

--- a/src/main/scala/com/raquo/airstream/state/Val.scala
+++ b/src/main/scala/com/raquo/airstream/state/Val.scala
@@ -6,7 +6,7 @@ import scala.util.{ Success, Try }
 
 class Val[A](override protected[this] val initialValue: Try[A]) extends WritableSignal[A] with StrictSignal[A] {
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   /** Value never changes, so we can use a simplified implementation */
   override def tryNow(): Try[A] = initialValue

--- a/src/main/scala/com/raquo/airstream/state/VarSignal.scala
+++ b/src/main/scala/com/raquo/airstream/state/VarSignal.scala
@@ -16,7 +16,7 @@ private[state] class VarSignal[A] private[state](
 ) extends WritableSignal[A] with StrictSignal[A] {
 
   /** SourceVar does not directly depend on other observables, so it breaks the graph. */
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   /** Note: we do not check if isStarted() here, this is how we ensure that this
     * signal's current value stays up to date. If this signal is stopped, this

--- a/src/main/scala/com/raquo/airstream/timing/DebounceEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/DebounceEventStream.scala
@@ -24,7 +24,7 @@ class DebounceEventStream[A](
 
   private[this] var maybeLastTimeoutHandle: js.UndefOr[SetTimeoutHandle] = js.undefined
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   /** Every time [[parent]] emits an event, we clear the previous timer and set a new one.
     * This stream only emits when the parent has stopped emitting for [[intervalMs]] ms.

--- a/src/main/scala/com/raquo/airstream/timing/DebounceEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/DebounceEventStream.scala
@@ -29,7 +29,7 @@ class DebounceEventStream[A](
   /** Every time [[parent]] emits an event, we clear the previous timer and set a new one.
     * This stream only emits when the parent has stopped emitting for [[intervalMs]] ms.
     */
-  override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
     maybeLastTimeoutHandle.foreach(js.timers.clearTimeout)
     maybeLastTimeoutHandle = js.defined(
       js.timers.setTimeout(intervalMs.toDouble) {

--- a/src/main/scala/com/raquo/airstream/timing/DelayEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/DelayEventStream.scala
@@ -16,7 +16,7 @@ class DelayEventStream[A](
 
   private val timerHandles: js.Array[SetTimeoutHandle] = js.Array()
 
-  override protected[airstream] def onNext(nextValue: A, transaction: Transaction): Unit = {
+  override protected def onNext(nextValue: A, transaction: Transaction): Unit = {
     var timerHandle: SetTimeoutHandle = null
     timerHandle = js.timers.setTimeout(delayMs.toDouble) {
       //println(s"> init trx from DelayEventStream.onNext($nextValue)")

--- a/src/main/scala/com/raquo/airstream/timing/DelayEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/DelayEventStream.scala
@@ -12,7 +12,7 @@ class DelayEventStream[A](
 ) extends WritableEventStream[A] with SingleParentObservable[A, A] with InternalNextErrorObserver[A] {
 
   /** Async stream, so reset rank */
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   private val timerHandles: js.Array[SetTimeoutHandle] = js.Array()
 

--- a/src/main/scala/com/raquo/airstream/timing/FutureEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/FutureEventStream.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
   */
 class FutureEventStream[A](future: Future[A], emitIfFutureCompleted: Boolean) extends WritableEventStream[A] {
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   if (!future.isCompleted || emitIfFutureCompleted) {
     // @TODO[API] Do we need "isStarted" filter on these? Doesn't seem to affect anything for now...

--- a/src/main/scala/com/raquo/airstream/timing/FutureSignal.scala
+++ b/src/main/scala/com/raquo/airstream/timing/FutureSignal.scala
@@ -22,7 +22,7 @@ class FutureSignal[A](
   future: Future[A]
 ) extends WritableSignal[Option[A]] with StrictSignal[Option[A]] {
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   override protected[this] def initialValue: Try[Option[A]] = future.value.fold[Try[Option[A]]](
     Success(None)

--- a/src/main/scala/com/raquo/airstream/timing/PeriodicEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/PeriodicEventStream.scala
@@ -16,7 +16,7 @@ class PeriodicEventStream[A](
   resetOnStop: Boolean
 ) extends WritableEventStream[A] {
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   private var currentValue: A = initial
 

--- a/src/main/scala/com/raquo/airstream/timing/SyncDelayEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/SyncDelayEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.timing
 
 import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
-import com.raquo.airstream.core.{BaseObservable, EventStream, SyncObservable, Transaction, WritableEventStream}
+import com.raquo.airstream.core.{EventStream, Protected, SyncObservable, Transaction, WritableEventStream}
 
 import scala.scalajs.js
 import scala.util.Try
@@ -13,7 +13,7 @@ class SyncDelayEventStream[A] (
 
   private[this] var maybePendingValue: js.UndefOr[Try[A]] = js.undefined
 
-  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parent :: after :: Nil) + 1
+  override protected val topoRank: Int = Protected.maxParentTopoRank(parent :: after :: Nil) + 1
 
   override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
     if (!transaction.pendingObservables.contains(this)) {

--- a/src/main/scala/com/raquo/airstream/timing/SyncDelayEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/SyncDelayEventStream.scala
@@ -1,7 +1,7 @@
 package com.raquo.airstream.timing
 
-import com.raquo.airstream.common.{ InternalTryObserver, SingleParentObservable }
-import com.raquo.airstream.core.{ EventStream, SyncObservable, Transaction, WritableEventStream }
+import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
+import com.raquo.airstream.core.{BaseObservable, EventStream, SyncObservable, Transaction, WritableEventStream}
 
 import scala.scalajs.js
 import scala.util.Try
@@ -13,7 +13,7 @@ class SyncDelayEventStream[A] (
 
   private[this] var maybePendingValue: js.UndefOr[Try[A]] = js.undefined
 
-  override protected[airstream] val topoRank: Int = js.Math.max(parent.topoRank, after.topoRank) + 1
+  override protected val topoRank: Int = BaseObservable.maxParentTopoRank(parent :: after :: Nil) + 1
 
   override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
     if (!transaction.pendingObservables.contains(this)) {

--- a/src/main/scala/com/raquo/airstream/timing/SyncDelayEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/SyncDelayEventStream.scala
@@ -15,7 +15,7 @@ class SyncDelayEventStream[A] (
 
   override protected val topoRank: Int = Protected.maxParentTopoRank(parent :: after :: Nil) + 1
 
-  override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
     if (!transaction.pendingObservables.contains(this)) {
        //println(s"Marking SyncDelayEventStream(${this.toString.substring(this.toString.indexOf('@'))}) as pending in TRX(${transaction.id})")
       transaction.pendingObservables.enqueue(this)

--- a/src/main/scala/com/raquo/airstream/timing/ThrottleEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/ThrottleEventStream.scala
@@ -33,7 +33,7 @@ class ThrottleEventStream[A](
 
   override protected val topoRank: Int = 1
 
-  override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
+  override protected def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
 
     val nowMs = js.Date.now()
 

--- a/src/main/scala/com/raquo/airstream/timing/ThrottleEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/timing/ThrottleEventStream.scala
@@ -31,7 +31,7 @@ class ThrottleEventStream[A](
 
   private[this] var maybeLastTimeoutHandle: js.UndefOr[SetTimeoutHandle] = js.undefined
 
-  override protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   override protected[airstream] def onTry(nextValue: Try[A], transaction: Transaction): Unit = {
 

--- a/src/main/scala/com/raquo/airstream/web/AjaxEventStream.scala
+++ b/src/main/scala/com/raquo/airstream/web/AjaxEventStream.scala
@@ -43,7 +43,7 @@ class AjaxEventStream(
   readyStateChangeObserver: Observer[dom.XMLHttpRequest] = Observer.empty
 ) extends WritableEventStream[dom.XMLHttpRequest] {
 
-  protected[airstream] val topoRank: Int = 1
+  override protected val topoRank: Int = 1
 
   private var pendingRequest: Option[dom.XMLHttpRequest] = None
 

--- a/src/test/scala/com/somebody/else/ExtensionSpec.scala
+++ b/src/test/scala/com/somebody/else/ExtensionSpec.scala
@@ -1,7 +1,7 @@
 package com.somebody.`else`
 
 import com.raquo.airstream.UnitSpec
-import com.raquo.airstream.core.{BaseObservable, Observable, Signal, WritableSignal}
+import com.raquo.airstream.core.{BaseObservable, Protected, Signal, WritableSignal}
 
 import scala.util.Try
 
@@ -13,7 +13,7 @@ class ExtensionSpec extends UnitSpec {
 
       override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
 
-      override protected def initialValue: Try[O] = ??? //parent.tryNow().map(project) // @nc
+      override protected def initialValue: Try[O] = Protected.tryNow(parent).map(project)
     }
   }
 }

--- a/src/test/scala/com/somebody/else/ExtensionSpec.scala
+++ b/src/test/scala/com/somebody/else/ExtensionSpec.scala
@@ -1,7 +1,8 @@
 package com.somebody.`else`
 
 import com.raquo.airstream.UnitSpec
-import com.raquo.airstream.core.{Protected, Signal, WritableSignal}
+import com.raquo.airstream.common.InternalTryObserver
+import com.raquo.airstream.core.{Protected, Signal, Transaction, WritableSignal}
 
 import scala.util.Try
 
@@ -9,11 +10,15 @@ class ExtensionSpec extends UnitSpec {
 
   it("Allow extension of observables including overriding and accessing all required methods") {
 
-    class ExtSignal[I, O](parent: Signal[I], project: I => O) extends WritableSignal[O] {
+    class ExtSignal[I, O](parent: Signal[I], project: I => O) extends WritableSignal[O] with InternalTryObserver[I] {
 
       override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
       override protected def initialValue: Try[O] = Protected.tryNow(parent).map(project)
+
+      override protected def onTry(nextParentValue: Try[I], transaction: Transaction): Unit = {
+        fireTry(nextParentValue.map(project), transaction)
+      }
     }
   }
 }

--- a/src/test/scala/com/somebody/else/ExtensionSpec.scala
+++ b/src/test/scala/com/somebody/else/ExtensionSpec.scala
@@ -1,0 +1,19 @@
+package com.somebody.`else`
+
+import com.raquo.airstream.UnitSpec
+import com.raquo.airstream.core.{BaseObservable, Observable, Signal, WritableSignal}
+
+import scala.util.Try
+
+class ExtensionSpec extends UnitSpec {
+
+  it("Allow extension of observables including overriding and accessing all required methods") {
+
+    class ExtSignal[I, O](parent: Signal[I], project: I => O) extends WritableSignal[O] {
+
+      override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+
+      override protected def initialValue: Try[O] = ??? //parent.tryNow().map(project) // @nc
+    }
+  }
+}

--- a/src/test/scala/com/somebody/else/ExtensionSpec.scala
+++ b/src/test/scala/com/somebody/else/ExtensionSpec.scala
@@ -1,7 +1,7 @@
 package com.somebody.`else`
 
 import com.raquo.airstream.UnitSpec
-import com.raquo.airstream.common.InternalTryObserver
+import com.raquo.airstream.common.{InternalTryObserver, SingleParentObservable}
 import com.raquo.airstream.core.{Protected, Signal, Transaction, WritableSignal}
 
 import scala.util.Try
@@ -10,7 +10,10 @@ class ExtensionSpec extends UnitSpec {
 
   it("Allow extension of observables including overriding and accessing all required methods") {
 
-    class ExtSignal[I, O](parent: Signal[I], project: I => O) extends WritableSignal[O] with InternalTryObserver[I] {
+    class ExtSignal[I, O](
+      override protected[this] val parent: Signal[I],
+      project: I => O
+    ) extends WritableSignal[O] with SingleParentObservable[I, O] with InternalTryObserver[I] {
 
       override protected val topoRank: Int = Protected.topoRank(parent) + 1
 

--- a/src/test/scala/com/somebody/else/ExtensionSpec.scala
+++ b/src/test/scala/com/somebody/else/ExtensionSpec.scala
@@ -1,7 +1,7 @@
 package com.somebody.`else`
 
 import com.raquo.airstream.UnitSpec
-import com.raquo.airstream.core.{BaseObservable, Protected, Signal, WritableSignal}
+import com.raquo.airstream.core.{Protected, Signal, WritableSignal}
 
 import scala.util.Try
 
@@ -11,7 +11,7 @@ class ExtensionSpec extends UnitSpec {
 
     class ExtSignal[I, O](parent: Signal[I], project: I => O) extends WritableSignal[O] {
 
-      override protected val topoRank: Int = BaseObservable.topoRank(parent) + 1
+      override protected val topoRank: Int = Protected.topoRank(parent) + 1
 
       override protected def initialValue: Try[O] = Protected.tryNow(parent).map(project)
     }


### PR DESCRIPTION
Fixes #79

I changed `topoRank`, `onNext`, `onError`, and `onTry` from `protected[airstream]` to `protected`.

With `protected` you generally can't access `observable.topoRank` from inside a _different_ observable instance, such inter-instance access is allowed only inside the `BaseObservable` trait where `topoRank` is defined, but not in any subtypes of that trait.

The new `Protected` object overcomes this limitation, allowing access to `topoRank`, `tryNow`, and `try` in this manner: `Protected.topoRank(otherObservable)`. To call these methods, you need implicit evidence of type `Protected`, which is defined in `trait BaseObservable` and is thus available inside any of its subtypes.

I couldn't figure out a better way to solve this issue (allowing extensions outside of com.raquo.airstream access to these methods). I think I've relaxed the access rules enough to make such extensions practical.

- [x] TODO: Write some docs