### PR TITLE
Add `EventStream.fromPublisher`

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,11 +432,20 @@ If you have an `Observable[Future[A]]`, you can flatten it into `Observable[A]` 
 
 A failed future results in an error (see [Error Handling](#error-handling)).
 
+#### Creating Observables from other Streaming APIs
+
+`EventStream.fromPublisher[A]` creates a stream that subscribes to a Reactive Streams [Publisher](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/Flow.Publisher.html) and emits the values that it produces.
+
+`Publisher` is a common interface that is useful for interoperating between streaming APIs. For example, you can transform an [FS2](https://fs2.io/) `Stream[IO, A]` into an `EventStream[A]`.
+
+```scala
+import cats.effect.unsafe.implicits._ // implicit IORuntime
+EventStream.fromPublisher(fs2Stream.unsafeToPublisher())
+```
 
 #### `EventStream.fromJsPromise` and `Signal.fromJsPromise`
 
 Behave the same as `fromFuture` above, but accept `js.Promise` instead. Useful for integration with JS libraries and APIs.
-
 
 #### `EventStream.fromSeq`
 

--- a/src/main/scala/com/raquo/airstream/core/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/EventStream.scala
@@ -14,6 +14,7 @@ import com.raquo.airstream.split.{SplittableOneStream, SplittableOptionStream, S
 import com.raquo.airstream.timing._
 import com.raquo.ew.JsArray
 
+import java.util.concurrent.Flow
 import scala.annotation.unused
 import scala.concurrent.{ExecutionContext, Future}
 import scala.scalajs.js
@@ -346,6 +347,30 @@ object EventStream {
 
   def fromJsPromise[A](promise: js.Promise[A], emitOnce: Boolean = false): EventStream[A] = {
     new JsPromiseStream[A](promise, emitOnce)
+  }
+
+  def fromFlowPublisher[A](mkPublisher: => Flow.Publisher[A], emitOnce: Boolean = false): EventStream[A] = {
+    var subscription: Flow.Subscription = null
+    fromCustomSource[A](
+      shouldStart = startIndex => if (emitOnce) startIndex == 1 else true,
+      start = (fireEvent, fireError, _, _) => {
+        
+        val publisher = mkPublisher
+        
+        val subscriber = new Flow.Subscriber[A] {
+          def onNext(a: A) = fireEvent(a)
+          def onError(t: Throwable) = fireError(t)
+          def onComplete() = ()
+          def onSubscribe(s: Flow.Subscription) = {
+            s.request(Long.MaxValue)
+            subscription = s
+          }
+        }
+
+        publisher.subscribe(subscriber)
+      },
+      stop = _ => { subscription.cancel(); subscription = null }
+    )
   }
 
   /** Easy helper for custom events. See [[CustomStreamSource]] for docs.

--- a/src/main/scala/com/raquo/airstream/core/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/EventStream.scala
@@ -349,7 +349,7 @@ object EventStream {
     new JsPromiseStream[A](promise, emitOnce)
   }
 
-  def fromFlowPublisher[A](publisher: Flow.Publisher[A], emitOnce: Boolean = false): EventStream[A] = {
+  def fromPublisher[A](publisher: Flow.Publisher[A], emitOnce: Boolean = false): EventStream[A] = {
     var subscription: Flow.Subscription = null
     fromCustomSource[A](
       shouldStart = startIndex => if (emitOnce) startIndex == 1 else true,

--- a/src/main/scala/com/raquo/airstream/core/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/EventStream.scala
@@ -367,10 +367,10 @@ object EventStream {
         publisher.subscribe(subscriber)
       },
       stop = _ => {
-      if (subscription ne null)
-        subscription.cancel()
-      subscription = null
-    }
+        if (subscription ne null)
+          subscription.cancel()
+        subscription = null
+      }
     )
   }
 

--- a/src/main/scala/com/raquo/airstream/core/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/EventStream.scala
@@ -349,14 +349,11 @@ object EventStream {
     new JsPromiseStream[A](promise, emitOnce)
   }
 
-  def fromFlowPublisher[A](mkPublisher: => Flow.Publisher[A], emitOnce: Boolean = false): EventStream[A] = {
+  def fromFlowPublisher[A](publisher: Flow.Publisher[A], emitOnce: Boolean = false): EventStream[A] = {
     var subscription: Flow.Subscription = null
     fromCustomSource[A](
       shouldStart = startIndex => if (emitOnce) startIndex == 1 else true,
-      start = (fireEvent, fireError, _, _) => {
-        
-        val publisher = mkPublisher
-        
+      start = (fireEvent, fireError, _, _) => {        
         val subscriber = new Flow.Subscriber[A] {
           def onNext(a: A) = fireEvent(a)
           def onError(t: Throwable) = fireError(t)

--- a/src/main/scala/com/raquo/airstream/core/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/EventStream.scala
@@ -369,7 +369,11 @@ object EventStream {
 
         publisher.subscribe(subscriber)
       },
-      stop = _ => { subscription.cancel(); subscription = null }
+      stop = _ => {
+      if (subscription ne null)
+        subscription.cancel()
+      subscription = null
+    }
     )
   }
 

--- a/src/test/scala/com/raquo/airstream/core/EventStreamSpec.scala
+++ b/src/test/scala/com/raquo/airstream/core/EventStreamSpec.scala
@@ -6,6 +6,7 @@ import com.raquo.airstream.fixtures.{Effect, TestableOwner}
 import com.raquo.airstream.ownership.Owner
 import org.scalactic.anyvals.NonEmptyList
 
+import java.util.concurrent.Flow
 import scala.collection.mutable
 
 class EventStreamSpec extends UnitSpec {
@@ -49,6 +50,37 @@ class EventStreamSpec extends UnitSpec {
     val sub2 = signal.foreach(newValue => effects += Effect("obs2", newValue))
 
     effects.toList shouldBe (3 +: range).map(i => Effect("obs2", i))
+    effects.clear()
+  }
+
+  it("EventStream.fromFlowPublisher") {
+
+    class RangePublisher(r: Range) extends Flow.Publisher[Int] {
+      def subscribe(subscriber: Flow.Subscriber[_ >: Int]): Unit = {
+        val subscription = new Flow.Subscription {
+          def request(n: Long) = r.foreach(subscriber.onNext(_))
+          def cancel() = ()
+        }
+        subscriber.onSubscribe(subscription)
+      }
+    }
+
+    implicit val owner: Owner = new TestableOwner
+
+    val range = 1 to 3
+    val stream = EventStream.fromFlowPublisher(new RangePublisher(range))
+
+    val effects = mutable.Buffer[Effect[_]]()
+    val sub1 = stream.foreach(newValue => effects += Effect("obs1", newValue))
+
+    effects.toList shouldBe range.map(i => Effect("obs1", i))
+    effects.clear()
+
+    sub1.kill()
+
+    val sub2 = stream.foreach(newValue => effects += Effect("obs2", newValue))
+
+    effects.toList shouldBe range.map(i => Effect("obs2", i))
     effects.clear()
   }
 

--- a/src/test/scala/com/raquo/airstream/core/EventStreamSpec.scala
+++ b/src/test/scala/com/raquo/airstream/core/EventStreamSpec.scala
@@ -53,7 +53,7 @@ class EventStreamSpec extends UnitSpec {
     effects.clear()
   }
 
-  it("EventStream.fromFlowPublisher") {
+  it("EventStream.fromPublisher") {
 
     class RangePublisher(r: Range) extends Flow.Publisher[Int] {
       def subscribe(subscriber: Flow.Subscriber[_ >: Int]): Unit = {
@@ -68,7 +68,7 @@ class EventStreamSpec extends UnitSpec {
     implicit val owner: Owner = new TestableOwner
 
     val range = 1 to 3
-    val stream = EventStream.fromFlowPublisher(new RangePublisher(range))
+    val stream = EventStream.fromPublisher(new RangePublisher(range))
 
     val effects = mutable.Buffer[Effect[_]]()
     val sub1 = stream.foreach(newValue => effects += Effect("obs1", newValue))


### PR DESCRIPTION
And effectively implementing (part of) the [Reactive Streams](https://www.reactive-streams.org/) spec.

In practice, this makes it possible to convert an `fs2.Stream` to an `EventStream` via the [`Flow.Publisher`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/Flow.Publisher.html) interface. Monix and ZIO also interop with Reactive Streams, although this is not cross-published for Scala.js yet.

Edit: [It turns out Monix also supports Reactive Streams on Scala.js!](https://github.com/monix/monix/blob/2faa2cf7425ab0b88ea57b1ea193bce16613f42a/monix-execution/js/src/main/scala/org/reactivestreams/Publisher.scala)