### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Fires a `Unit`, or another value, if provided, `ms` milliseconds after the strea
 
 An event stream that emits events at an interval. `EventStream.periodic` emits the index of the event, starting with `0` for the initial event that's emitted without delay. If you want to skip the initial event, use `.drop(1)`. The `resetOnStop` option (`false` by default) determines whether the index will be reset to `0` when the stream is stopped due to lack of observers. You can also reset the stream to any index manually by calling `resetTo(value)` on it. This will immediately emit this new index.
 
-The underlying `PeriodicEventStream` class offers more functionality, including the ability to emit values other than index, set a custom interval for every subsequent event, and stop the stream while it still has observers.
+The underlying `PeriodicStream` class offers more functionality, including the ability to emit values other than index, set a custom interval for every subsequent event, and stop the stream while it still has observers.
 
 
 #### `EventStream.empty`


### PR DESCRIPTION
Change PeriodicEventStream to PeriodicStream

Definition of EventStream.periodic is:

```
  def periodic(
    intervalMs: Int,
    resetOnStop: Boolean = false
  ): PeriodicStream[Int] = {
    new PeriodicStream[Int](
      initial = 0,
      next = eventNumber => Some((eventNumber + 1, intervalMs)),
      resetOnStop = resetOnStop
    )
  }
```

hence, I assume that the underlying class name has changed.