### PR TITLE
New: `.splitByIndex` and `.splitOption` for vars

### DIFF
--- a/src/main/scala/com/raquo/airstream/extensions/OptionVar.scala
+++ b/src/main/scala/com/raquo/airstream/extensions/OptionVar.scala
@@ -1,0 +1,59 @@
+package com.raquo.airstream.extensions
+
+import com.raquo.airstream.core.Signal
+import com.raquo.airstream.state.{LazyDerivedVar, LazyStrictSignal, Var}
+import com.raquo.airstream.split.DuplicateKeysConfig
+
+class OptionVar[A](val v: Var[Option[A]]) extends AnyVal {
+
+  /** This `.split`-s a Var of an Option by the Option's `isDefined` property.
+    * If you want a different key, use the .split operator directly.
+    *
+    * @param project - (initialInput, varOfInput) => output
+    *                  `project` is called whenever the parent var switches from `None` to `Some()`.
+    *                  `varOfInput` starts with `initialInput` value, and updates when
+    *                  the parent var updates from `Some(a)` to `Some(b)`.
+    * @param ifEmpty - returned if Option is empty. Evaluated whenever the parent var
+    *                  switches from `Some(a)` to `None`, or when the parent var
+    *                  starts with a `None`. `ifEmpty` is NOT re-evaluated when the
+    *                  parent var emits `None` if its value is already `None`.
+    */
+  def splitOption[B](
+    project: (A, Var[A]) => B,
+    ifEmpty: => B
+  ): Signal[B] = {
+    // Note: We never have duplicate keys here, so we can use
+    // DuplicateKeysConfig.noWarnings to improve performance
+    v.signal
+      .distinctByFn((prev, next) => prev.isEmpty && next.isEmpty) // Ignore consecutive `None` events
+      .split(
+        key = _ => (),
+        duplicateKeys = DuplicateKeysConfig.noWarnings
+      )(
+        (_, initial, signal) => {
+          val displayNameSuffix = s".splitOption(Some)"
+          val childVar = new LazyDerivedVar[Option[A], A](
+            parent = v,
+            signal = new LazyStrictSignal[A, A](
+              signal, identity, signal.displayName, displayNameSuffix + ".signal"
+            ),
+            zoomOut = (inputs, newInput) => {
+              Some(newInput)
+            },
+            displayNameSuffix = displayNameSuffix
+          )
+          project(initial, childVar)
+        }
+      )
+      .map(_.getOrElse(ifEmpty))
+  }
+
+  def splitOption[B](
+    project: (A, Var[A]) => B
+  ): Signal[Option[B]] = {
+    splitOption(
+      (initial, someVar) => Some(project(initial, someVar)),
+      ifEmpty = None
+    )
+  }
+}

--- a/src/main/scala/com/raquo/airstream/split/Splittable.scala
+++ b/src/main/scala/com/raquo/airstream/split/Splittable.scala
@@ -36,6 +36,18 @@ trait Splittable[M[_]] {
     })
   }
 
+  def findUpdateByIndex[A](inputs: M[A], index: Int, newItem: A): M[A] = {
+    var ix = -1
+    map(inputs, (input: A) => {
+      ix += 1
+      if (ix == index) {
+        newItem
+      } else {
+        input
+      }
+    })
+  }
+
   def zipWithIndex[A](inputs: M[A]): M[(A, Int)] = {
     var ix = -1
     map(inputs, (input: A) => {

--- a/src/main/scala/com/raquo/airstream/state/Var.scala
+++ b/src/main/scala/com/raquo/airstream/state/Var.scala
@@ -3,6 +3,7 @@ package com.raquo.airstream.state
 import com.raquo.airstream.core.AirstreamError.VarError
 import com.raquo.airstream.core.Source.SignalSource
 import com.raquo.airstream.core.{AirstreamError, Named, Observer, Signal, Sink, Transaction}
+import com.raquo.airstream.extensions.OptionVar
 import com.raquo.airstream.ownership.Owner
 import com.raquo.airstream.split.SplittableVar
 import com.raquo.airstream.util.hasDuplicateTupleKeys
@@ -278,5 +279,9 @@ object Var {
 
   /** Provides methods on Var: split, splitMutate */
   implicit def toSplittableVar[M[_], Input](signal: Var[M[Input]]): SplittableVar[M, Input] = new SplittableVar(signal)
+
+  /** Provides methods on Var: splitOption */
+  implicit def toOptionVar[A](v: Var[Option[A]]): OptionVar[A] = new OptionVar(v)
+
 }
 


### PR DESCRIPTION
Here is my attempt at adding some common operators for Var. I mostly copied and adapted what was already done for Signal.
The tests are very much a copy of the Signal equivalent. I'd be happy to add more if you want to cover more specific cases.