### PR TITLE
Fix: Add binary compatibility forwarder for EventStream.recover

### DIFF
--- a/src/main/scala/com/raquo/airstream/core/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/EventStream.scala
@@ -39,6 +39,13 @@ with DynamicImportStreamOps[A] // dynamicImport (Scala 3 only)
     new MapStream(this, project, recover = None)
   }
 
+  // BinCompat forwarder: In 17.x, recover was defined directly on EventStream.
+  // In 18.0.0-M3 it moved to RecoverOps[Self, A] where Self has no
+  // `<: Observable[_]` bound, changing the Scala.js IR method descriptor.
+  // This forwarder restores the old descriptor so that libraries compiled
+  // against 17.x (e.g. caliban) can link against 18.x.
+  override def recover[B >: A](pf: PartialFunction[Throwable, Option[B]]): EventStream[B] = mapRecover(identity, pf)
+
   /** If `recover` is defined and needs to be called, it can do the following:
     *  - Return Some(value) to make this stream emit value
     *  - Return None to make this stream ignore (swallow) this error


### PR DESCRIPTION
## Summary

- Add a single forwarding override for `recover` on `EventStream`
- Restores the Scala.js IR method descriptor that libraries compiled against Airstream 17.x expect

Fixes #149

## Context

As diagnosed by @sjrd in [this comment](https://github.com/raquo/Airstream/issues/149#issuecomment-3973941873), `RecoverOps[+Self[+_], +A]` has `Self` without the `<: Observable[_]` upper bound that `BaseObservable` has. When `recover` moved to `RecoverOps` in 18.0.0-M3, the Scala.js IR method descriptor changed (erased return type went from `Observable` to `Object`), breaking binary compatibility for downstream libraries compiled against 17.x.

The fix is minimal: only `EventStream.recover` needs a forwarder, since caliban (the affected library) only calls `.map` and `.recover` on `EventStream`, and `.map` is already overridden.

## Reproduction

https://github.com/nguyenyou/airstream-recover-bincompat-repro

## Test plan

- [x] All 309 Airstream tests pass
- [x] Verified with [minimal repro](https://github.com/nguyenyou/airstream-recover-bincompat-repro): library compiled against Airstream 17.2.1 now links successfully with the patched Airstream 18.x


🤖 Generated with [Claude Code](https://claude.com/claude-code)