### PR TITLE
Refactor: Extracted "Signal.updates()" and related methods into a separate trait.

### DIFF
--- a/src/main/scala/com/raquo/airstream/common/SingleParentSignal.scala
+++ b/src/main/scala/com/raquo/airstream/common/SingleParentSignal.scala
@@ -1,8 +1,8 @@
 package com.raquo.airstream.common
 
+import com.raquo.airstream.conversions.SignalFromStream
 import com.raquo.airstream.core.{Observable, Protected, Signal, Transaction, WritableSignal}
 import com.raquo.airstream.distinct.DistinctSignal
-import com.raquo.airstream.misc.SignalFromStream
 import com.raquo.airstream.split.SplitChildSignal
 
 import scala.util.Try

--- a/src/main/scala/com/raquo/airstream/conversions/SignalFromStream.scala
+++ b/src/main/scala/com/raquo/airstream/conversions/SignalFromStream.scala
@@ -1,4 +1,4 @@
-package com.raquo.airstream.misc
+package com.raquo.airstream.conversions
 
 import com.raquo.airstream.common.SingleParentSignal
 import com.raquo.airstream.core.{EventStream, Protected, Transaction}

--- a/src/main/scala/com/raquo/airstream/conversions/StreamFromSignal.scala
+++ b/src/main/scala/com/raquo/airstream/conversions/StreamFromSignal.scala
@@ -1,4 +1,4 @@
-package com.raquo.airstream.misc
+package com.raquo.airstream.conversions
 
 import com.raquo.airstream.common.{InternalTryObserver, SingleParentStream}
 import com.raquo.airstream.core.{Protected, Signal, Transaction}

--- a/src/main/scala/com/raquo/airstream/conversions/UpdatesSignalOps.scala
+++ b/src/main/scala/com/raquo/airstream/conversions/UpdatesSignalOps.scala
@@ -1,0 +1,77 @@
+package com.raquo.airstream.conversions
+
+import com.raquo.airstream.core.{EventStream, Signal}
+import org.scalajs.dom.MouseEvent
+
+import scala.util.Try
+
+/**
+ * A base type for observables that have a stream of updates (namely, only [[Signal]] and its subtypes).
+ *
+ * @tparam A The type of value emitted by this observable. (e.g. [[MouseEvent]] or [[Int]].)
+ */
+trait UpdatesSignalOps[+A] {
+
+  // #TODO[API] Why is .updates a def, and not a lazy val?
+  //  See `signal.updates shouldNotBe signal.updates` in SignalSpec
+  /** A stream of all values in this signal, excluding the initial value.
+   *
+   * When re-starting this stream, it emits the signal's new current value
+   * if and only if something has caused the signal's value to be updated
+   * or re-evaluated while the updates stream was stopped. This way the
+   * updates stream stays in sync with the signal even after restarting.
+   */
+  def updates: EventStream[A]
+
+  /** Get the signal's current value */
+  protected[airstream] def tryNow(): Try[A]
+
+  /** Modify the Signal's changes stream, e.g. signal.composeChanges(_.delay(ms = 100))
+   *
+   * Alias to changes(operator). See also: [[composeAll]]
+   *
+   * @param operator Note: Must not throw!
+   */
+  @inline final def composeUpdates[AA >: A](
+    operator: EventStream[A] => EventStream[AA]
+  ): Signal[AA] = {
+    composeAll(updatesOperator = operator, initialOperator = identity)
+  }
+
+  /** Modify both the Signal's changes stream, and its initial.
+   * Similar to composeChanges, but lets you output a type unrelated to A.
+   *
+   * @param updatesOperator Note: Must not throw!
+   * @param initialOperator Note: Must not throw!
+   */
+  @inline final def composeAll[B](
+    updatesOperator: EventStream[A] => EventStream[B],
+    initialOperator: Try[A] => Try[B],
+    cacheInitialValue: Boolean = false
+  ): Signal[B] = {
+    updatesOperator(updates).toSignalWithTry(initialOperator(tryNow()), cacheInitialValue)
+  }
+
+  /** Modify the Signal's updates, e.g. signal.updates(_.delay(ms = 100))
+   *
+   * Alias to [[composeUpdates]]. See also: [[composeAll]]
+   *
+   * @param compose Note: Must not throw!
+   */
+  @inline final def updates[AA >: A](compose: EventStream[A] => EventStream[AA]): Signal[AA] = {
+    composeUpdates(compose)
+  }
+
+  @deprecated("signal.composeChanges renamed to signal.composeUpdates", since = "18.0.0-M3")
+  @inline final def composeChanges[AA >: A](
+    operator: EventStream[A] => EventStream[AA]
+  ): Signal[AA] = {
+    composeUpdates(operator)
+  }
+
+  @deprecated("signal.changes renamed to signal.updates", since = "18.0.0-M3")
+  def changes: EventStream[A] = updates
+
+  @deprecated("signal.changes renamed to signal.updates", since = "18.0.0-M3")
+  def changes[AA >: A](compose: EventStream[A] => EventStream[AA]): Signal[AA] = updates(compose)
+}

--- a/src/main/scala/com/raquo/airstream/core/EventStream.scala
+++ b/src/main/scala/com/raquo/airstream/core/EventStream.scala
@@ -2,6 +2,7 @@ package com.raquo.airstream.core
 
 import com.raquo.airstream.combine.{CombineStreamN, MergeStream}
 import com.raquo.airstream.combine.generated.{CombineStreamObjectOps, CombineStreamOps}
+import com.raquo.airstream.conversions.SignalFromStream
 import com.raquo.airstream.core.Source.{EventSource, SignalSource}
 import com.raquo.airstream.custom.{CustomSource, CustomStreamSource}
 import com.raquo.airstream.custom.CustomSource._

--- a/src/main/scala/com/raquo/airstream/core/Signal.scala
+++ b/src/main/scala/com/raquo/airstream/core/Signal.scala
@@ -2,6 +2,7 @@ package com.raquo.airstream.core
 
 import com.raquo.airstream.combine.CombineSignalN
 import com.raquo.airstream.combine.generated.{CombineSignalObjectOps, CombineSignalOps}
+import com.raquo.airstream.conversions.{StreamFromSignal, UpdatesSignalOps}
 import com.raquo.airstream.core.Source.SignalSource
 import com.raquo.airstream.custom.{CustomSignalSource, CustomSource}
 import com.raquo.airstream.custom.CustomSource._
@@ -9,11 +10,12 @@ import com.raquo.airstream.debug.{Debugger, DebuggerSignal, DebugOps, DebugSigna
 import com.raquo.airstream.distinct.{DistinctOps, DistinctSignal}
 import com.raquo.airstream.dynamicImport.{DynamicImportSignalObjectOps, DynamicImportSignalOps}
 import com.raquo.airstream.extensions._
-import com.raquo.airstream.misc.{MapSignal, ScanLeftSignal, StreamFromSignal}
+import com.raquo.airstream.misc.{MapSignal, ScanLeftSignal}
 import com.raquo.airstream.ownership.Owner
 import com.raquo.airstream.state.{ObservedSignal, OwnedSignal, Val}
 import com.raquo.airstream.timing.JsPromiseSignal
 import com.raquo.ew.JsArray
+import org.scalajs.dom.svg.A
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.scalajs.js
@@ -27,6 +29,7 @@ with BaseObservable[Signal, A]
 with SignalSource[A]
 with CombineSignalOps[A] // combineWith, combineWithFn, withCurrentValueOf, sample
 with ScanLeftSignalOps[Signal, A] // scanLeft, scanLeftRecover
+with UpdatesSignalOps[A]
 with DebugSignalOps[Signal, A] // debug* (debugLogEvents, debugSpyAll, etc.)
 with DynamicImportSignalOps[A] // dynamicImport (Scala 3 only)
 {
@@ -67,70 +70,7 @@ with DynamicImportSignalOps[A] // dynamicImport (Scala 3 only)
     new MapSignal[A, B](parent = this, projectValue, recover = Some(recoverError))
   }
 
-  /** @param operator Note: Must not throw! */
-  def compose[B](operator: Signal[A] => Signal[B]): Signal[B] = {
-    operator(this)
-  }
-
-  /** Modify the Signal's changes stream, e.g. signal.composeChanges(_.delay(ms = 100))
-    *
-    * Alias to changes(operator). See also: [[composeAll]]
-    *
-    * @param operator Note: Must not throw!
-    */
-  def composeUpdates[AA >: A](
-    operator: EventStream[A] => EventStream[AA]
-  ): Signal[AA] = {
-    composeAll(updatesOperator = operator, initialOperator = identity)
-  }
-
-  /** Modify both the Signal's changes stream, and its initial.
-    * Similar to composeChanges, but lets you output a type unrelated to A.
-    *
-    * @param updatesOperator Note: Must not throw!
-    * @param initialOperator Note: Must not throw!
-    */
-  def composeAll[B](
-    updatesOperator: EventStream[A] => EventStream[B],
-    initialOperator: Try[A] => Try[B],
-    cacheInitialValue: Boolean = false
-  ): Signal[B] = {
-    updatesOperator(updates).toSignalWithTry(initialOperator(tryNow()), cacheInitialValue)
-  }
-
-  // #TODO[API] Why is .updates a def, and not a lazy val?
-  //  See `signal.updates shouldNotBe signal.updates` in SignalSpec
-  /** A stream of all values in this signal, excluding the initial value.
-    *
-    * When re-starting this stream, it emits the signal's new current value
-    * if and only if something has caused the signal's value to be updated
-    * or re-evaluated while the updates stream was stopped. This way the
-    * updates stream stays in sync with the signal even after restarting.
-    */
-  def updates: EventStream[A] = new StreamFromSignal[A](parent = this, updatesOnly = true)
-
-  /** Modify the Signal's updates, e.g. signal.updates(_.delay(ms = 100))
-    *
-    * Alias to [[composeUpdates]]. See also: [[composeAll]]
-    *
-    * @param compose Note: Must not throw!
-    */
-  @inline def updates[AA >: A](compose: EventStream[A] => EventStream[AA]): Signal[AA] = {
-    composeUpdates(compose)
-  }
-
-  @deprecated("signal.composeChanges renamed to signal.composeUpdates", since = "18.0.0-M3")
-  def composeChanges[AA >: A](
-    operator: EventStream[A] => EventStream[AA]
-  ): Signal[AA] = {
-    composeUpdates(operator)
-  }
-
-  @deprecated("signal.changes renamed to signal.updates", since = "18.0.0-M3")
-  def changes: EventStream[A] = updates
-
-  @deprecated("signal.changes renamed to signal.updates", since = "18.0.0-M3")
-  def changes[AA >: A](compose: EventStream[A] => EventStream[AA]): Signal[AA] = updates(compose)
+  @inline def updates: EventStream[A] = new StreamFromSignal[A](parent = this, updatesOnly = true)
 
   @deprecated("foldLeft was renamed to scanLeft", "15.0.0-M1")
   def foldLeft[B](makeInitial: A => B)(fn: (B, A) => B): Signal[B] = scanLeft(makeInitial)(fn)


### PR DESCRIPTION
# Extracted "Signal.updates()" and related methods into a separate trait.

1. Extracted `updates`, `composeUpdates`, `composeAll`, `updates()`, `composeChanges`, `changes`, and `changes()` from `Signal` into `conversions.UpdatesSignalOps`.
2. Moved `SignalFromStream` and `StreamFromSignal` from package `misc` to `conversions`.